### PR TITLE
nicely deprecates DEFAULT_MAIL_SENDER 

### DIFF
--- a/budget/default_settings.py
+++ b/budget/default_settings.py
@@ -3,7 +3,7 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:///budget.db'
 SQLACHEMY_ECHO = DEBUG
 SECRET_KEY = "tralala"
 
-DEFAULT_MAIL_SENDER = ("Budget manager", "budget@notmyidea.org")
+MAIL_DEFAULT_SENDER = ("Budget manager", "budget@notmyidea.org")
 
 try:
     from settings import *

--- a/budget/requirements.txt
+++ b/budget/requirements.txt
@@ -1,7 +1,7 @@
 flask>=0.9
 flask-wtf==0.8
 flask-sqlalchemy
-flask-mail
+flask-mail>=0.8
 flask-babel
 flask-rest
 jinja2==2.6

--- a/budget/run.py
+++ b/budget/run.py
@@ -1,3 +1,5 @@
+import warnings
+
 from flask import Flask, g, request, session
 from flask.ext.babel import Babel
 from raven.contrib.flask import Sentry
@@ -8,6 +10,18 @@ from api import api
 
 app = Flask(__name__)
 app.config.from_object("default_settings")
+
+# Deprecations
+if 'DEFAULT_MAIL_SENDER' in app.config:
+    # Since flask-mail  0.8
+    warnings.warn(
+        "DEFAULT_MAIL_SENDER is deprecated in favor of MAIL_DEFAULT_SENDER"
+        +" and will be removed in further version",
+        UserWarning
+    )
+    if not 'MAIL_DEFAULT_SENDER' in app.config:
+        app.config['MAIL_DEFAULT_SENDER'] = DEFAULT_MAIL_SENDER
+
 
 app.register_blueprint(main)
 app.register_blueprint(api)


### PR DESCRIPTION
… as it changed upstream for flask-mail>=0.8

Note that it breaks default installation (as reported in #120).

For the record, this change has been made very quiet at flask-mail, see https://github.com/mattupstate/flask-mail/issues/51