### PR TITLE
specified sizes for string columns for MySQL

### DIFF
--- a/budget/models.py
+++ b/budget/models.py
@@ -17,11 +17,11 @@ class Project(db.Model):
     _to_serialize = ("id", "name", "password", "contact_email",
             "members", "active_members", "balance")
 
-    id = db.Column(db.String, primary_key=True)
+    id = db.Column(db.String(64), primary_key=True)
 
     name = db.Column(db.UnicodeText)
-    password = db.Column(db.String)
-    contact_email = db.Column(db.String)
+    password = db.Column(db.String(128))
+    contact_email = db.Column(db.String(128))
     members = db.relationship("Person", backref="project")
 
     @property
@@ -155,7 +155,7 @@ class Person(db.Model):
     _to_serialize = ("id", "name", "activated")
 
     id = db.Column(db.Integer, primary_key=True)
-    project_id = db.Column(db.String, db.ForeignKey("project.id"))
+    project_id = db.Column(db.String(64), db.ForeignKey("project.id"))
     bills = db.relationship("Bill", backref="payer")
 
     name = db.Column(db.UnicodeText)
@@ -230,7 +230,7 @@ class Bill(db.Model):
 
 class Archive(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    project_id = db.Column(db.String, db.ForeignKey("project.id"))
+    project_id = db.Column(db.String(64), db.ForeignKey("project.id"))
     name = db.Column(db.UnicodeText)
 
     @property


### PR DESCRIPTION
Otherwise, the mysql sqlalchemy connector complains (cause VARCHAR2 of MySQL should have a max size defined).

For information, I made this change to package ihatemoney for [yunohost](https://yunohost.org)