### PR TITLE
Bugfix rounding settle algorithm

### DIFF
--- a/budget/models.py
+++ b/budget/models.py
@@ -62,7 +62,7 @@ class Project(db.Model):
                 debts.append({"person": person, "balance": -balance[person.id]})
         # Try and find exact matches
         for credit in credits:
-            match = self.exactmatch(credit["balance"], debts)
+            match = self.exactmatch(round(credit["balance"], 2), debts)
             if match:
                 for m in match:
                     transactions.append({"ower": m["person"], "receiver": credit["person"], "amount": m["balance"]})


### PR DESCRIPTION
In some cases, settle algorithm failed to deliver optimal solution due to a rounding bug. Spotted by @sschnug. See this discussion (https://github.com/spiral-project/ihatemoney/pull/96) for more information.

I'm not sure this is the correct way to fix this. The better solution will be to use Decimal type instead of float type to store currency.
Unfortunatly, this involve quite a lot of changes, and maybe a migration strategy for actual database.
