### PR TITLE
Do not load user-overriden settings in unit tests.

### DIFF
--- a/budget/default_settings.py
+++ b/budget/default_settings.py
@@ -4,9 +4,3 @@ SQLACHEMY_ECHO = DEBUG
 SECRET_KEY = "tralala"
 
 MAIL_DEFAULT_SENDER = ("Budget manager", "budget@notmyidea.org")
-APPLICATION_ROOT = '/'
-
-try:
-    from settings import *
-except ImportError:
-    pass

--- a/budget/merged_settings.py
+++ b/budget/merged_settings.py
@@ -1,0 +1,10 @@
+"""
+Merges default settings with user-defined settings
+"""
+
+from default_settings import *
+
+try:
+    from settings import *
+except ImportError:
+    pass

--- a/budget/run.py
+++ b/budget/run.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 from flask import Flask, g, request, session
@@ -14,7 +15,8 @@ app = Flask(__name__)
 def configure():
     """ A way to (re)configure the app, specially reset the settings
     """
-    app.config.from_object("default_settings")
+    config_obj = os.environ.get('FLASK_SETTINGS_MODULE', 'merged_settings')
+    app.config.from_object(config_obj)
     app.wsgi_app = PrefixedWSGI(app)
 
     # Deprecations

--- a/budget/tests.py
+++ b/budget/tests.py
@@ -5,8 +5,11 @@ except ImportError:
     import unittest  # NOQA
 
 import base64
+import os
 import json
 from collections import defaultdict
+
+os.environ['FLASK_SETTINGS_MODULE'] = 'default_settings'
 
 from flask import session
 


### PR DESCRIPTION
Loading not versionned settings.py during tests make them less predictable. (Stumbled upon issues working on tests for #122 )