### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ How about the REST API?
 =======================
 
 Yep, you're right, there is a REST API with this. Head to the `api
-documentation <http://readthedocs.org/docs/ihatemoney/en/latest/api.html>`_ to know more.
+documentation <https://ihatemoney.readthedocs.io/en/latest/api.html>`_ to know more.
 
 How to contribute
 =================

--- a/budget/migrations/env.py
+++ b/budget/migrations/env.py
@@ -55,7 +55,7 @@ def run_migrations_online():
 
     # This callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema.
-    # reference: http://alembic.readthedocs.org/en/latest/cookbook.html
+    # reference: https://alembic.readthedocs.io/en/latest/cookbook.html
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, 'autogenerate', False):
             script = directives[0]


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.