### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r budget/requirements.txt"
+# command to run tests
+script: cd budget && python tests.py

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Budget-manager
 ##############
 
+.. image:: https://travis-ci.org/spiral-project/ihatemoney.svg?branch=master
+   :target: https://travis-ci.org/spiral-project/ihatemoney
+   :alt: Travis CI Build Status
+
 This is a really tiny app to ease the shared houses budget management. Keep
 track of who bought what, when, and for who to then compute the balance of each
 person.


### PR DESCRIPTION
Add a travis.yml file to enable Continuous Integration with Travis CI (https://travis-ci.org/)

Currently two tests are failing so the build is not green, but environment setup and tests are properly executed by Travis.