### PR TITLE
Sort bills by (date.desc, ID.desc) instead of just date.desc

### DIFF
--- a/budget/models.py
+++ b/budget/models.py
@@ -111,7 +111,8 @@ class Project(db.Model):
             .filter(Bill.payer_id == Person.id)\
             .filter(Person.project_id == Project.id)\
             .filter(Project.id == self.id)\
-            .order_by(Bill.date.desc())
+            .order_by(Bill.date.desc())\
+            .order_by(Bill.id.desc())
 
     def remove_member(self, member_id):
         """Remove a member from the project.


### PR DESCRIPTION
When viewing the list of bills, bills are (correctly) sorted by date.  But
the order of all bills for a given day is not intuitive: I would expect
bills to be sorted by reverse order of insertion.  That is, the last bill
to be added for a given day should appear first, not last.  Otherwise,
when adding several bills in a row for a given day, it's confusing to see
that the new bills do not appear on top of the list.

Fix this by sorting by decreasing ID after sorting by date.