### PR TITLE
Fix ServerTestCase.test_unprefixed test

### DIFF
--- a/budget/tests.py
+++ b/budget/tests.py
@@ -934,6 +934,7 @@ class ServerTestCase(APITestCase):
         super(ServerTestCase, self).setUp()
 
     def test_unprefixed(self):
+        run.app.config['APPLICATION_ROOT'] = '/'
         req = self.app.get("/foo/")
         self.assertStatus(303, req)
 


### PR DESCRIPTION
The test was always failing, actual reason is the `app.run.configure()` fails
to reset the `APPLICATION_ROOT` setting which `ServerTestCase.test_prefixed`
overloads (side effect).

This patch *do not* fix app.run.configure as it seems uneasy, but takes a
different approach which has the advantage of making the test more explicit.

Would still be a good thing to investigate more on configure().

Fix #163