### PR TITLE
Add a .gitlab-ci file in order to run continuous integration on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+image: python:2.7
+
+test:
+  script:
+    - pip install -r budget/requirements.txt
+    - cd budget && python tests.py


### PR DESCRIPTION
Add a simple gitlab-ci for those who prefer to use gitlab instead of github.

It could be interesting to add some staging and deploy environments too.