### PR TITLE
Make travis use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: cd budget && python tests.py
+script: tox
+install:
+  - pip install tox
+env:
+  - TOXENV=py27
+  - TOXENV=py35
+  - TOXENV=docs


### PR DESCRIPTION
So that we are consistent between dev test env and CI test env.
The use of `TOXENV` is to keep travis running the several envs in parallel.