### PR TITLE
Add Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ install:
   - pip install tox
 env:
   - TOXENV=py27
+  - TOXENV=py34
   - TOXENV=py35
   - TOXENV=docs

--- a/budget/utils.py
+++ b/budget/utils.py
@@ -99,7 +99,9 @@ def list_of_dicts2csv(dict_to_convert):
     try:
         if six.PY3:
             csv_file = StringIO()
-            csv_data = [dict_to_convert[0].keys()]
+            # using list() for py3.4 compat. Otherwise, writerows() fails
+            # (expecting a sequence getting a view)
+            csv_data = [list(dict_to_convert[0].keys())]
             for dic in dict_to_convert:
                 csv_data.append([dic[h] for h in dict_to_convert[0].keys()])
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py27,docs
+envlist = py35,py34,py27,docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Note that py3.4 is the version shipped in current Debian version (Jessie).

~That's a WIP, because it will need to be rebased (and modified) after #186 gets merged.~ DONE