### PR TITLE
Add meta viewport tag

### DIFF
--- a/budget/templates/layout.html
+++ b/budget/templates/layout.html
@@ -4,6 +4,7 @@
 <head>
     <title>{{ _("Account manager") }}{% block title %}{% endblock %}</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel=stylesheet type=text/css href="{{ url_for("static", filename='css/main.css') }}">
     <script src="{{ url_for("static", filename="js/jquery-3.1.1.min.js") }}"></script>
     <script src="{{ url_for("static", filename="js/ihatemoney.js") }}"></script>


### PR DESCRIPTION
I've just realized it was missing a `meta` tag.

Still not perfect, but incidentally it fixes #219.

Footer can be truncated on small screen, I do not have quick fix for this :/