### PR TITLE
Fix #248: Database creation issue

### DIFF
--- a/ihatemoney/default_settings.py
+++ b/ihatemoney/default_settings.py
@@ -8,7 +8,7 @@ DEBUG = False
 
 # The database URI, reprensenting the type of database and how to connect to it.
 # Enter an absolute path here.
-SQLALCHEMY_DATABASE_URI = 'sqlite://'
+SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/ihatemoney.db'
 SQLACHEMY_ECHO = DEBUG
 
 # Will likely become the default value in flask-sqlalchemy >=3 ; could be removed

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -77,7 +77,7 @@ class ConfigurationTestCase(BaseTestCase):
     def test_default_configuration(self):
         """Test that default settings are loaded when no other configuration file is specified"""
         self.assertFalse(self.app.config['DEBUG'])
-        self.assertEqual(self.app.config['SQLALCHEMY_DATABASE_URI'], 'sqlite://')
+        self.assertEqual(self.app.config['SQLALCHEMY_DATABASE_URI'], 'sqlite:////tmp/ihatemoney.db')
         self.assertFalse(self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
         self.assertEqual(self.app.config['MAIL_DEFAULT_SENDER'],
                          ("Budget manager", "budget@notmyidea.org"))


### PR DESCRIPTION
In flask's development server, the route handlers
run in a different thread than the main thread
thus an in-memory database created in the main thread
cannot be acccessed by the route handlers.
Switching the default database location to a temporary
file solves the isssue.

See full explanation here:
https://gehrcke.de/2015/05/in-memory-sqlite-database-and-flask-a-threading-trap/