### PR TITLE
Fix misplaced datepicker configuration

### DIFF
--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -21,13 +21,6 @@
                 });
             }, 4000);
 
-            $('.datepicker').datepicker({
-                format: 'yyyy-mm-dd',
-                weekStart: 1,
-                autoclose: true,
-                language: '{{ g.lang }}'
-            });
-
             $('.dropdown-toggle').dropdown();
 
             {% block js %}{% endblock %}

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -8,6 +8,13 @@
 {% block js %}
     {% if add_bill %} $('#new-bill').click(); {% endif %}
 
+    $('.datepicker').datepicker({
+        format: 'yyyy-mm-dd',
+        weekStart: 1,
+        autoclose: true,
+        language: '{{ g.lang }}'
+    });
+
     // Hide all members actions
     $('.action').each(function(){
         $(this).hide();


### PR DESCRIPTION
Bootstrap-datepicker is only included in the
list_bills template but its configuration was
living in the layout template, leading to a
javascript error on every page except list_bills.

Fixes #256