### PR TITLE
Fix default SQLALCHEMY_DATABASE_URI value in doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -92,12 +92,12 @@ properly.
 
 .. warning:: You **must** customize the ``SECRET_KEY`` on a production installation.
 
-+-------------------------------+---------------------------+----------------------------------------------------------------------------------------+
-| Setting name                  |  Default                  | What does it do?                                                                       |
-+===============================+===========================+========================================================================================+
-| SQLALCHEMY_DATABASE_URI       |  ``sqlite:///budget.db``  | Specifies the type of backend to use and its location. More information                |
-|                               |                           | on the format used can be found on `the SQLAlchemy documentation                       |
-|                               |                           | <http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_.              |
++-------------------------------+---------------------------------+----------------------------------------------------------------------------------+
+| Setting name                  |  Default                        | What does it do?                                                                 |
++===============================+=================================+==================================================================================+
+| SQLALCHEMY_DATABASE_URI       | ``sqlite:///tmp/ihatemoney.db`` | Specifies the type of backend to use and its location. More information          |
+|                               |                                 | on the format used can be found on `the SQLAlchemy documentation                 |
+|                               |                                 | <http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_.        |
 +-------------------------------+---------------------------+----------------------------------------------------------------------------------------+
 | SECRET_KEY                    |  ``tralala``              | The secret key used to encrypt the cookies. **This needs to be changed**.              |
 +-------------------------------+---------------------------+----------------------------------------------------------------------------------------+


### PR DESCRIPTION
Reality-sync with default_settings.py

Not fixing the whole table layout because

- my text editor doesn't do it ;
- I'm too lazy ;
- #251 is IMHO the real way to this issue :)