### PR TITLE
BREAKING CHANGE: Rename supervisor program

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,4 +1,4 @@
-[program:budget]
+[program:ihatemoney]
 command=/path/to/your/app/venv/bin/gunicorn -c /etc/ihatemoney/gunicorn.conf.py ihatemoney.wsgi:application
 user=www
 autostart=true


### PR DESCRIPTION
To match `budget` name disparition (package got renamed in #243).

This should be mentioned in upgrade guide.

ref #243 #264 

Is this housekeeping night ? :-)