### PR TITLE
Use hashed passwords for projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 - Use token based auth to reset passwords (#269)
 - Better install doc (#275)
 - Use token based auth in invitation e-mails (#280)
+- Use hashed passwords for projects (#286)
 
 Added
 =====

--- a/ihatemoney/api.py
+++ b/ihatemoney/api.py
@@ -5,6 +5,7 @@ from flask_rest import RESTResource, need_auth
 from ihatemoney.models import db, Project, Person, Bill
 from ihatemoney.forms import (ProjectForm, EditProjectForm, MemberForm,
                               get_billform_for)
+from werkzeug.security import check_password_hash
 
 
 api = Blueprint("api", __name__, url_prefix="/api")
@@ -21,7 +22,7 @@ def check_project(*args, **kwargs):
     if auth and "project_id" in kwargs and \
             auth.username == kwargs["project_id"]:
         project = Project.query.get(auth.username)
-        if project and project.password == auth.password:
+        if project and check_password_hash(project.password, auth.password):
             return project
     return False
 

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -5,6 +5,7 @@ from wtforms.fields.simple import PasswordField, SubmitField, TextAreaField, Str
 from wtforms.validators import Email, Required, ValidationError, EqualTo
 from flask_babel import lazy_gettext as _
 from flask import request
+from werkzeug.security import generate_password_hash
 
 from datetime import datetime
 from jinja2 import Markup
@@ -52,14 +53,14 @@ class EditProjectForm(FlaskForm):
         Returns the created instance
         """
         project = Project(name=self.name.data, id=self.id.data,
-                          password=self.password.data,
+                          password=generate_password_hash(self.password.data),
                           contact_email=self.contact_email.data)
         return project
 
     def update(self, project):
         """Update the project with the information from the form"""
         project.name = self.name.data
-        project.password = self.password.data
+        project.password = generate_password_hash(self.password.data)
         project.contact_email = self.contact_email.data
 
         return project

--- a/ihatemoney/migrations/versions/b78f8a8bdb16_hash_project_passwords.py
+++ b/ihatemoney/migrations/versions/b78f8a8bdb16_hash_project_passwords.py
@@ -1,0 +1,41 @@
+"""hash project passwords
+
+Revision ID: b78f8a8bdb16
+Revises: f629c8ef4ab0
+Create Date: 2017-12-17 11:45:44.783238
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b78f8a8bdb16'
+down_revision = 'f629c8ef4ab0'
+
+from alembic import op
+import sqlalchemy as sa
+from werkzeug.security import generate_password_hash
+
+project_helper = sa.Table(
+    'project', sa.MetaData(),
+    sa.Column('id', sa.String(length=64), nullable=False),
+    sa.Column('name', sa.UnicodeText(), nullable=True),
+    sa.Column('password', sa.String(length=128), nullable=True),
+    sa.Column('contact_email', sa.String(length=128), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    for project in connection.execute(project_helper.select()):
+        connection.execute(
+            project_helper.update().where(
+                project_helper.c.name == project.name
+            ).values(
+                password=generate_password_hash(project.password)
+            )
+        )
+
+
+def downgrade():
+    # Downgrade path is not possible, because information has been lost.
+    pass

--- a/ihatemoney/templates/reminder_mail.en
+++ b/ihatemoney/templates/reminder_mail.en
@@ -2,8 +2,7 @@ Hi,
 
 You have just (or someone else using your email address) created the project "{{ g.project.name }}" to share your expenses.
 
-You can access it here: {{ url_for(".list_bills", _external=True) }} (the identifier is {{ g.project.id }}),
-and the shared password is "{{ g.project.password }}".
+You can access it here: {{ url_for(".list_bills", _external=True) }} (the identifier is {{ g.project.id }}).
 If you want to share this project with your friends, you can share the identifier and the shared password with them or send them invitations with the following link:
 {{ url_for(".invite", _external=True) }}
 

--- a/ihatemoney/templates/reminder_mail.fr
+++ b/ihatemoney/templates/reminder_mail.fr
@@ -2,8 +2,7 @@ Hey,
 
 Vous venez de créer le projet "{{ g.project.name }}" pour partager vos dépenses.
 
-Vous pouvez y accéder ici: {{ url_for(".list_bills", _external=True) }} (l'identifieur est {{ g.project.id }}),
-et le code d'accès "{{ g.project.password }}".
+Vous pouvez y accéder ici: {{ url_for(".list_bills", _external=True) }} (l'identifieur est {{ g.project.id }}).
 Si vous voulez partager ce projet avec vos amis, vous pouvez partager son identifiant et son code d'accès avec eux ou leur envoyer une invitation avec le lien suivant :
 {{ url_for(".invite", _external=True) }}
 


### PR DESCRIPTION
- Remove all occurences of clear text project passwords.
- Migrate the database to hash the previously stored passwords.
Closes #232