### PR TITLE
Remove un-needed sidebar block

### DIFF
--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -74,7 +74,6 @@
 
 <div class="container-fluid">
 {% block body %}
-    {% block sidebar %}{% endblock %}
     <main class="content offset-1 col-10">
     {% block content %}{% endblock %}
     </main>


### PR DESCRIPTION
{% block sidebar %} is used by sidebar_table_layout.html and its children, not by
layout.html nor its direct children.

This is dead code removal.