### PR TITLE
 Fix PUT api/project/:code/members/:id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,11 @@ Added
 - Dockerfile
 - Documentation explaining the upgrade process
 
+Fixed
+=====
+
+- Fix `PUT api/project/:code/members/:id` API endpoint (#295)
+
 Removed
 =======
 

--- a/ihatemoney/api.py
+++ b/ihatemoney/api.py
@@ -79,7 +79,7 @@ class MemberHandler(object):
         return 400, form.errors
 
     def update(self, project, member_id):
-        form = MemberForm(project, meta={'csrf': False})
+        form = MemberForm(project, meta={'csrf': False}, edit=True)
         if form.validate():
             member = Person.query.get(member_id, project)
             form.save(project, member)

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -1185,7 +1185,6 @@ class APITestCase(IhatemoneyTestCase):
         self.assertStatus(200, req)
 
         # the list of members should be empty
-        # get the list of members (should be empty)
         req = self.client.get("/api/projects/raclette/members",
                               headers=self.get_auth("raclette"))
 

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -1155,7 +1155,8 @@ class APITestCase(IhatemoneyTestCase):
 
         # edit this member
         req = self.client.put("/api/projects/raclette/members/1", data={
-            "name": "Fred"
+            "name": "Fred",
+            "weight": 2,
         }, headers=self.get_auth("raclette"))
 
         self.assertStatus(200, req)
@@ -1166,6 +1167,15 @@ class APITestCase(IhatemoneyTestCase):
 
         self.assertStatus(200, req)
         self.assertEqual("Fred", json.loads(req.data.decode('utf-8'))["name"])
+        self.assertEqual(2, json.loads(req.data.decode('utf-8'))["weight"])
+
+        # edit this member with same information
+        # (test PUT idemopotence)
+        req = self.client.put("/api/projects/raclette/members/1", data={
+            "name": "Fred"
+        }, headers=self.get_auth("raclette"))
+
+        self.assertStatus(200, req)
 
         # delete a member
 


### PR DESCRIPTION
Before that commit, every PUT *must* change the name of the members, so that was:
- no idempotence,
- no ability to change only weight

fix #295

(for the story, it took me more time to write #295 yesterday than to fix the bug today :p)