### PR TITLE
Fix some anti patterns in docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,8 @@ ENV DEBUG="False" \
     ACTIVATE_DEMO_PROJECT="True" \
     ADMIN_PASSWORD="" \
     ALLOW_PUBLIC_PROJECT_CREATION="True" \
-    ACTIVATE_ADMIN_DASHBOARD="False" \
-    GUNICORN_NUM_WORKERS="3"
+    ACTIVATE_ADMIN_DASHBOARD="False"
 
 VOLUME /database
 EXPOSE 8000
-CMD ["/ihatemoney/conf/confandrun.sh"]
+ENTRYPOINT ["/ihatemoney/conf/confandrun.sh"]

--- a/conf/confandrun.sh
+++ b/conf/confandrun.sh
@@ -17,7 +17,8 @@ ADMIN_PASSWORD = "$ADMIN_PASSWORD"
 ALLOW_PUBLIC_PROJECT_CREATION = $ALLOW_PUBLIC_PROJECT_CREATION
 ACTIVATE_ADMIN_DASHBOARD = $ACTIVATE_ADMIN_DASHBOARD
 EOF
-gunicorn ihatemoney.wsgi:application \
--b 0.0.0.0:8000 \
---log-syslog \
--w "$GUNICORN_NUM_WORKERS"
+# Start gunicorn without forking
+exec gunicorn ihatemoney.wsgi:application \
+     -b 0.0.0.0:8000 \
+     --log-syslog \
+     "$@"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -154,9 +154,10 @@ A volume can also be specified to persist the default database file::
 
     docker run -d -p 8000:8000 -v /host/path/to/database:/database ihatemoney
 
-The following gunicorn parameters are also available::
+Additional gunicorn parameters can be passed using the docker ``CMD`` parameter.
+For example, use the following command to add more gunicorn workers::
 
-    GUNICORN_NUM_WORKERS (default: 3)
+    docker run -d -p 8000:8000 ihatemoney -w 3
 
 Configuration
 =============


### PR DESCRIPTION
- Use exec to run gunicorn and avoid creating a new process.
- Add the possibility to pass any additional parameters to
gunicorn.
- Use only one gunicorn worker by default as the usual way to
scale the app in production would be to use the scale command
of the cluster scheduler. Additional workers could still be
added by passing the "-w" gunicorn parameter to docker run.