### PR TITLE
Document MySQL setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,15 @@ This document describes changes between each past release.
 2.1.1 (unreleased)
 ------------------
 
+Fixed
+=====
+
 - Regenerate translations (#338)
+
+Added
+=====
+
+- Document MySQL setup (#357)
 
 
 2.1 (2018-02-16)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,6 +63,22 @@ Once installed, you can start a test server::
 
 And point your browser at `http://localhost:5000 <http://localhost:5000>`_.
 
+Configure database with MySQL/MariaDB (optional)
+================================================
+
+Only required if you prefer MySQL/MariaDB over SQLite.
+
+1. Install PyMySQL dependencies. On Debian or Ubuntu, that would be::
+
+    apt install python3-dev libssl-dev
+
+2. Install PyMySQL (within your virtualenv)::
+
+    pip install 'PyMySQL>=0.9,<0.10'
+
+3. Create an empty database and a database user
+4. Configure :ref:`SQLALCHEMY_DATABASE_URI <configuration>` accordingly
+
 Deploy it
 =========
 
@@ -159,6 +175,8 @@ For example, use the following command to add more gunicorn workers::
 
     docker run -d -p 8000:8000 ihatemoney -w 3
 
+.. _configuration:
+
 Configuration
 =============
 
@@ -187,7 +205,7 @@ Production values are recommended values for use in production.
 |                               |                                 | **Production value:** `ihatemoney conf-example ihatemoney.cfg` sets it to something    |
 |                               |                                 | random, which is good.                                                                 |
 +-------------------------------+---------------------------------+----------------------------------------------------------------------------------------+
-| MAIL_DEFAULT_SENDER           | ``("Budget manager",            | A python tuple describing the name and email address to use when sending                |
+| MAIL_DEFAULT_SENDER           | ``("Budget manager",            | A python tuple describing the name and email address to use when sending               |
 |                               | "budget@notmyidea.org")``       | emails.                                                                                |
 |                               |                                 |                                                                                        |
 |                               |                                 |  **Production value:** Any tuple you want.                                             |


### PR DESCRIPTION
PyMySQL is more difficult to install since its version 0.9 since it now depends
on *cryptography* lib, which in turns depends on OpenSSL and Python dev files.

See https://github.com/PyMySQL/PyMySQL/issues/697

side-note : I am pretty sure it breaks the docker setup, but I do not use docker, anyone to check and fix ? @0livd ?