### PR TITLE
Remove strict_slashes for /

### DIFF
--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -1434,6 +1434,12 @@ class APITestCase(IhatemoneyTestCase):
 
 class ServerTestCase(IhatemoneyTestCase):
 
+    def test_homepage(self):
+        # See https://github.com/spiral-project/ihatemoney/pull/358
+        self.app.config['APPLICATION_ROOT'] = '/'
+        req = self.client.get("/")
+        self.assertStatus(200, req)
+
     def test_unprefixed(self):
         self.app.config['APPLICATION_ROOT'] = '/'
         req = self.client.get("/foo/")

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -198,7 +198,7 @@ def authenticate(project_id=None):
     return render_template("authenticate.html", form=form)
 
 
-@main.route("/")
+@main.route("/", strict_slashes=False)
 def home():
     project_form = ProjectForm()
     auth_form = AuthenticationForm()


### PR DESCRIPTION
I don't know why, but on my setup (nginx + uwsgi), the `strict_slashes` (default to `True`) was causing an infinite loop.
I think it could be safely removed for this route only.