### PR TITLE
Fix Apache conf template, without relying on environment var

### DIFF
--- a/ihatemoney/conf-templates/apache-vhost.conf.j2
+++ b/ihatemoney/conf-templates/apache-vhost.conf.j2
@@ -1,7 +1,7 @@
 <VirtualHost *:80>
     ServerAdmin admin@example.com      # CUSTOMIZE
     ServerName ihatemoney.example.com  # CUSTOMIZE
-    WSGIDaemonProcess ihatemoney user=www-data group=www-data threads=5 python-path={{ pkg_path }} {% if bin_path %}python-home={{ bin_path }}{% endif %}
+    WSGIDaemonProcess ihatemoney user=www-data group=www-data threads=5 python-home={{ sys_prefix }}
     WSGIScriptAlias / {{ pkg_path }}/wsgi.py
     WSGIPassAuthorization On
 

--- a/ihatemoney/manage.py
+++ b/ihatemoney/manage.py
@@ -52,6 +52,7 @@ class GenerateConfig(Command):
         print(template.render(
                 pkg_path=pkg_path,
                 bin_path=bin_path,
+                sys_prefix=sys.prefix,
                 secret_key=self.gen_secret_key(),
         ))
 


### PR DESCRIPTION
`python-home` is prefered over `python-path`. It will work with or without
a virtualenv.

See http://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html