### PR TITLE
Fix cffi installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.6-alpine
 
-RUN mkdir /ihatemoney &&\
+RUN apk add gcc libc-dev libffi-dev openssl-dev &&\
+    mkdir /ihatemoney &&\
     mkdir -p /etc/ihatemoney &&\
     pip install --no-cache-dir gunicorn pymysql
 


### PR DESCRIPTION
The Python cffi package requires the libc, libffi and openssl
development packages, as well as gcc to compile it.

These packages are not included in the alpine image by default.