### PR TITLE
Fix failing tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 - Fix the generation of the supervisord template (#309)
 - Fix the validation of the hashed password (#310)
 - Fix infinite loop that happened when accessing / (#358)
+- Fix email validation when sending invites
 
 Added
 =====

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -10,6 +10,8 @@ from werkzeug.security import generate_password_hash
 from datetime import datetime
 from jinja2 import Markup
 
+import email_validator
+
 from ihatemoney.models import Project, Person
 from ihatemoney.utils import slugify
 
@@ -184,9 +186,10 @@ class InviteForm(FlaskForm):
     submit = SubmitField(_("Send invites"))
 
     def validate_emails(form, field):
-        validator = Email()
         for email in [email.strip() for email in form.emails.data.split(",")]:
-            if not validator.regex.match(email):
+            try:
+                email_validator.validate_email(email)
+            except email_validator.EmailNotValidError as e:
                 raise ValidationError(_("The email %(email)s is not valid",
                                         email=email))
 

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -186,7 +186,7 @@ def create_jinja_env(folder, strict_rendering=False):
         kwargs['undefined'] = jinja2.StrictUndefined
     return jinja2.Environment(**kwargs)
 
-  
+
 class IhmJSONEncoder(JSONEncoder):
     """Subclass of the default encoder to support custom objects.
     Taken from the deprecated flask-rest package."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ raven
 blinker
 six>=1.10
 itsdangerous>=0.24
+email_validator>=1.0


### PR DESCRIPTION
With the introduction of email_validator, the wtform API changed, and the validation of email fields was broken in the invitation mechanism.

This pull request hopefully fixes this, and at the same time make all the tests pass on our CI.