### PR TITLE
Fix double-click when deleting a bill (#349)

### DIFF
--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -513,7 +513,7 @@ def delete_bill(bill_id):
     # fixme: everyone is able to delete a bill
     bill = Bill.query.get(g.project, bill_id)
     if not bill:
-        raise NotFound()
+        return redirect(url_for('.list_bills'))
 
     db.session.delete(bill)
     db.session.commit()


### PR DESCRIPTION
When double-clicking on the delete button, the first click actually
deletes the bill, and the second click does the same action again. But
as the bill is already deleted, it displays a 404 page which can be
misleading.

This fix makes the app trigger a redirect when the bill seem to doesn't
exist, fixing this strange behaviour.