### PR TITLE
Add a contributing section to the readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,10 @@ Requirements
 
 * **Python**: 2.7, 3.4, 3.5, 3.6.
 * **Backends**: MySQL, PostgreSQL, SQLite, Memory.
+
+Contributing
+============
+
+Do you wish to contribute to IHateMoney? Fantastic! There's a lot of very
+useful help on the official `contributing
+<https://ihatemoney.readthedocs.io/en/latest/contributing.html>`_ page.


### PR DESCRIPTION
Hi there! Since it took me around 15 minutes to discover the Contributing page on the documentation site (I started by looking at the Makefile and other places, and figured out the listening port after trial and error and looking up what the default for Flask was), how about we add a small Contributing section in the readme file, just linking to the documentation website? :slightly_smiling_face: 