### PR TITLE
get_bills() returns all bills from all project

### DIFF
--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -160,8 +160,6 @@ class Project(db.Model):
     def get_bills(self):
         """Return the list of bills related to this project"""
         return Bill.query.join(Person, Project)\
-            .filter(Bill.payer_id == Person.id)\
-            .filter(Person.project_id == Project.id)\
             .filter(Project.id == self.id)\
             .order_by(Bill.date.desc())\
             .order_by(Bill.id.desc())


### PR DESCRIPTION
I don't know why, the old ORM was generating this query:
```SQL
SELECT bill.id AS bill_id, bill.payer_id AS bill_payer_id, bill.amount AS bill_amount, bill.date AS bill_date, bill.what AS bill_what, bill.archive AS bill_archive 
FROM bill JOIN person ON person.id = bill.payer_id JOIN project ON project.id = person.project_id 
WHERE bill.payer_id = person.id AND person.project_id = project.id AND project.id = ? ORDER BY bill.date DESC, bill.id DESC
```
which seems OK, given the code.

But, on my setup, this now returns ALL bills from ALL projects. This is weird, it is late, I'm tired, and I found that removing the `WHERE` constraints (except the one for the project id) fix this issue.

The new code generate this:
```SQL
SELECT bill.id AS bill_id, bill.payer_id AS bill_payer_id, bill.amount AS bill_amount, bill.date AS bill_date, bill.what AS bill_what, bill.archive AS bill_archive 
FROM bill JOIN person ON person.id = bill.payer_id JOIN project ON project.id = person.project_id 
WHERE project.id = ? ORDER BY bill.date DESC, bill.id DESC
```
which seems better, given the fact that the `JOIN` clause already restricts things.

Please test this on your local branch.