### PR TITLE
fix: display validation message on password reminder

### DIFF
--- a/ihatemoney/templates/display_message.html
+++ b/ihatemoney/templates/display_message.html
@@ -1,0 +1,8 @@
+{% extends "layout.html" %}
+
+{% block content %}
+<h2>{{ _(title) }}</h2>
+<p>
+    {{message}}
+</p>
+{% endblock %}

--- a/ihatemoney/templates/password_reminder_sent.html
+++ b/ihatemoney/templates/password_reminder_sent.html
@@ -5,4 +5,6 @@
 <p>
     {{message}}
 </p>
+<a class="btn btn-primary" href="{{ url_for('.home')}}">Return to home page</a>
+    
 {% endblock %}

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -271,16 +271,21 @@ def remind_password():
         if form.validate():
             # get the project
             project = Project.query.get(form.id.data)
-
             # send a link to reset the password
             password_reminder = "password_reminder.%s.j2" % get_locale().language
             current_app.mail.send(Message(
                 "password recovery",
                 body=render_template(password_reminder, project=project),
                 recipients=[project.contact_email]))
-            flash(_("A link to reset your password has been sent to your email."))
+            return redirect(url_for(".password_reminder_sent"))
 
     return render_template("password_reminder.html", form=form)
+
+
+@main.route("/password-reminder-sent", methods=["GET"])
+def password_reminder_sent():
+    message = "A link to reset your password has been sent to you, please check your emails"
+    return render_template("display_message.html", title="Password reminder", message=message)
 
 
 @main.route('/reset-password', methods=['GET', 'POST'])

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -284,8 +284,12 @@ def remind_password():
 
 @main.route("/password-reminder-sent", methods=["GET"])
 def password_reminder_sent():
-    message = "A link to reset your password has been sent to you, please check your emails"
-    return render_template("display_message.html", title="Password reminder", message=message)
+    message = "A link to reset your password has been sent to you, please check your emails."
+    return render_template(
+        "password_reminder_sent.html",
+        title="Password reminder",
+        message=message
+        )
 
 
 @main.route('/reset-password', methods=['GET', 'POST'])


### PR DESCRIPTION
Create a new route with a new generic page that display a title and a message on a <p> tag. This route will be triggered after succesfully submit password reminder form

See issue #455