### PR TITLE
Paginate the list of bills

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -272,6 +272,15 @@ footer .footer-left {
   margin-top: 30px;
 }
 
+#previous-page {
+  margin-top: 30px;
+}
+
+#next-page {
+  margin-top: 30px;
+  padding-left: 2em;
+}
+
 /* Avoid text color flickering when it loose focus as the modal appears */
 .btn-primary[data-toggle="modal"] {
   color: #fff;

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -97,13 +97,23 @@
         </div>
     </div>
 
-    {% if bills.count() > 0 %}
+{% if bills.pages > 1 %}
+    <span id="previous-page" class="float-left">
+      <a class="btn btn-outline-secondary float-left {% if bills.page == 1 %}disabled{% endif %}" href="{{ url_for('main.list_bills', page=bills.prev_num) }}">&laquo; {{ _("Newer bills") }}</a>
+    </span>
+
+    <span id="next-page" class="float-left">
+      <a class="btn btn-outline-secondary float-left {% if bills.page == bills.pages %}disabled{% endif %}" href="{{ url_for('main.list_bills', page=bills.next_num) }}">{{ _("Older bills") }} &raquo;</a>
+    </span>
+{% endif %}
+
+    {% if bills.total > 0 %}
         <div class="clearfix"></div>
 
         <table id="bill_table" class="col table table-striped table-hover table-responsive-sm">
             <thead><tr><th>{{ _("When?") }}</th><th>{{ _("Who paid?") }}</<th><th>{{ _("For what?") }}</th><th>{{ _("For whom?") }}</th><th>{{ _("How much?") }}</th><th>{{ _("Actions") }}</th></tr></thead>
         <tbody>
-        {% for bill in bills %}
+        {% for bill in bills.items %}
         <tr owers="{{bill.owers|join(',','id')}}" payer="{{bill.payer.id}}">
                 <td>
                     <span data-toggle="tooltip" data-placement="top"
@@ -132,6 +142,20 @@
         {% endfor %}
         </tbody>
         </table>
+
+{% if bills.pages > 1 %}
+<ul class="pagination">
+  <li class="page-item {% if bills.page == 1 %}disabled{% endif %}"><a class="page-link" href="{{ url_for('main.list_bills', page=bills.prev_num) }}">&laquo; Newer bills</a></li>
+  {%- for page in bills.iter_pages() %}
+  {% if page %}
+  <li class="page-item {% if page == bills.page %}active{% endif %}"><a class="page-link" href="{{ url_for('main.list_bills', page=page) }}">{{ page }}</a></li>
+  {% else %}
+  <li class="page-item disabled"><span class="ellipsis page-link">…</span></li>
+  {% endif %}
+  {%- endfor %}
+  <li class="page-item {% if bills.page == bills.pages %}disabled{% endif %}"><a class="page-link" href="{{ url_for('main.list_bills', page=bills.next_num) }}">Older bills &raquo;</a></li>
+</ul>
+{% endif %}
 
     {% else %}
         <div class="py-3 d-flex justify-content-center empty-bill">

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -586,7 +586,11 @@ def list_bills():
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
     # Preload the "owers" relationship for all bills
-    bills = g.project.get_bills().options(orm.subqueryload(Bill.owers))
+    bills = (
+        g.project.get_bills()
+        .options(orm.subqueryload(Bill.owers))
+        .paginate(per_page=100, error_out=True)
+    )
 
     return render_template(
         "list_bills.html",


### PR DESCRIPTION
This is a work-in-progress proposal to paginate the list of bills. The main motivation is that I have 1095 bills, and the list of bills is starting to be slow to display!

Before investing time in design etc, I would like to first gather some feedback on the idea itself.

By default, the first page is displayed (most recent bills). Older bills can be displayed with the `page` URL parameter:

```
$URL/project/?page=42
```

Documentation for this feature in flask-sqlalchemy is here:

https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.BaseQuery.paginate
https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.Pagination

Some things to improve:

- decide on the number of bills to display on each page (20 items by default, which is probably fine)
- decide what happens when fetching an out-of-range page. Currently it just displays an empty table, but we can also return a 404.
- maybe add a link to the previous and next page above the table?
- better style for the list of pages
- implement the same thing in the API! (would be useful for MoneyBuster, it's also really slow to synchronise with 1000 bills)

Here is a screenshot, with only 2 items per page for testing:

![screenshot demo](https://files.polyno.me/tmp/ihatemoney.png)