### PR TITLE
Added install of ihatemoney module to documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -27,7 +27,7 @@ Alternatively, you can also use the `requirements.txt` file to install the
 dependencies yourself. That would be::
 
      pip install -r requirements.txt
-     pip install .
+     pip install -e .
 
 And then run the application::
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -27,6 +27,7 @@ Alternatively, you can also use the `requirements.txt` file to install the
 dependencies yourself. That would be::
 
      pip install -r requirements.txt
+     pip install .
 
 And then run the application::
 


### PR DESCRIPTION
I have tried to follow instructions in https://ihatemoney.readthedocs.io/en/latest/contributing.html in order to run the server.
It has been impossible to configure it. Finally I have discovered that the errors was that ihatemoney module should be installed before run "python run.py".
I have updated the documentation in order to reflect it.
