### PR TITLE
Added support to generate token of project

### DIFF
--- a/ihatemoney/api.py
+++ b/ihatemoney/api.py
@@ -186,8 +186,21 @@ class BillHandler(Resource):
         return "OK", 200
 
 
+class TokenHandler(Resource):
+    method_decorators = [need_auth]
+
+    def get(self, project):
+        print(project)
+        if not project:
+            return "Not Found", 404
+        token = project.generate_token()
+        print(token)
+        return {"token": token}, 200
+
+
 restful_api.add_resource(ProjectsHandler, "/projects")
 restful_api.add_resource(ProjectHandler, "/projects/<string:project_id>")
+restful_api.add_resource(TokenHandler, "/token/<string:project_id>")
 restful_api.add_resource(MembersHandler, "/projects/<string:project_id>/members")
 restful_api.add_resource(
     ProjectStatsHandler, "/projects/<string:project_id>/statistics"

--- a/ihatemoney/api.py
+++ b/ihatemoney/api.py
@@ -1,5 +1,5 @@
 # coding: utf8
-from flask import Blueprint, request
+from flask import Blueprint, request, current_app
 from flask_restful import Resource, Api, abort
 from flask_cors import CORS
 from wtforms.fields.core import BooleanField
@@ -55,7 +55,7 @@ def need_auth(f):
 class ProjectsHandler(Resource):
     def post(self):
         form = ProjectForm(meta={"csrf": False})
-        if form.validate():
+        if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             project = form.save()
             db.session.add(project)
             db.session.commit()
@@ -76,7 +76,7 @@ class ProjectHandler(Resource):
 
     def put(self, project):
         form = EditProjectForm(meta={"csrf": False})
-        if form.validate():
+        if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             form.update(project)
             db.session.commit()
             return "UPDATED"

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -298,7 +298,7 @@ class BudgetTestCase(IhatemoneyTestCase):
             # session is not updated
             self.assertNotIn("raclette", session)
 
-            # project is created
+            # project is not created
             self.assertEqual(len(models.Project.query.all()), 0)
 
     def test_project_creation_with_public_permissions(self):

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -281,6 +281,46 @@ class BudgetTestCase(IhatemoneyTestCase):
             # no new project added
             self.assertEqual(len(models.Project.query.all()), 1)
 
+    def test_project_creation_without_public_permissions(self):
+        self.app.config["ALLOW_PUBLIC_PROJECT_CREATION"] = False
+        with self.app.test_client() as c:
+            # add a valid project
+            c.post(
+                "/create",
+                data={
+                    "name": "The fabulous raclette party",
+                    "id": "raclette",
+                    "password": "party",
+                    "contact_email": "raclette@notmyidea.org",
+                },
+            )
+
+            # session is not updated
+            self.assertNotIn("raclette", session)
+
+            # project is created
+            self.assertEqual(len(models.Project.query.all()), 0)
+
+    def test_project_creation_with_public_permissions(self):
+        self.app.config["ALLOW_PUBLIC_PROJECT_CREATION"] = True
+        with self.app.test_client() as c:
+            # add a valid project
+            c.post(
+                "/create",
+                data={
+                    "name": "The fabulous raclette party",
+                    "id": "raclette",
+                    "password": "party",
+                    "contact_email": "raclette@notmyidea.org",
+                },
+            )
+
+            # session is updated
+            self.assertTrue(session["raclette"])
+
+            # project is created
+            self.assertEqual(len(models.Project.query.all()), 1)
+
     def test_project_deletion(self):
 
         with self.app.test_client() as c:

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -1357,6 +1357,29 @@ class APITestCase(IhatemoneyTestCase):
         )
         self.assertEqual(401, resp.status_code)
 
+    def test_token_creation(self):
+        """Test that token of project is generated
+        """
+
+        # Create project
+        resp = self.api_create("raclette")
+        self.assertTrue(201, resp.status_code)
+
+        # Get token
+        resp = self.client.get("/api/token/raclette", headers=self.get_auth("raclette"))
+
+        self.assertEqual(200, resp.status_code)
+
+        decoded_resp = json.loads(resp.data.decode("utf-8"))
+
+        # Access with token
+        resp = self.client.get(
+            "/api/token/raclette",
+            headers={"Authorization": "Basic %s" % decoded_resp["token"]},
+        )
+
+        self.assertEqual(200, resp.status_code)
+
     def test_member(self):
         # create a project
         self.api_create("raclette")


### PR DESCRIPTION
Now with endpoint /api/token/<project_id> you will get a {"token": "tokenofproject"} that you can use in GET "/api/project" with header "Authenthication: token <token>".

Hope it helps!

Issue: #412 