### PR TITLE
prevent bill cancellation when cancelling autocomplete

### DIFF
--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -78,7 +78,7 @@
 
 {% block content %}
     <span id="new-bill" class="float-right"  {% if not g.project.members %} data-toggle="tooltip" title="{{_('You should start by adding participants')}}" {% endif %}>
-        <a href="{{ url_for('.add_bill') }}" class="btn btn-primary float-right {% if not g.project.members %} disabled {% endif %}" data-toggle="modal" data-target="#bill-form">
+        <a href="{{ url_for('.add_bill') }}" class="btn btn-primary float-right {% if not g.project.members %} disabled {% endif %}" data-toggle="modal" data-keyboard="false" data-target="#bill-form">
             <i class="icon icon-white plus">{{ static_include("images/plus.svg") | safe }}</i>
             {{ _("Add a new bill") }}
         </a>


### PR DESCRIPTION
# Addresses https://github.com/spiral-project/ihatemoney/issues/125

-As @almet suggested adding `data-keyboard = "false"` prevents the bill from being cancelled when hitting the `ESC` key to cancel out of autocomplete