### PR TITLE
Address #430, Bill List Search by Payer

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -169,6 +169,14 @@ body {
   width: 5em;
 }
 
+#bill-search {
+  color: white;
+  background: #8f9296;
+  margin-top: 10px;
+  border-radius: .25rem;
+  padding: .375rem .75rem;
+}
+
 .invites textarea {
   width: 800px;
   height: 100px;

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -16,6 +16,19 @@
             return false;
         });
     });
+    
+    $('#btn-bill-search').click(function() {
+        var value = $('#payer-search-select option:selected').val();
+        var matching = $('#bill_table tbody tr').filter(function(){
+            return $(this).attr('payer') !== value;
+        });
+        matching.hide();
+        $('#bill_table tbody tr').not(matching).show(200);
+    });
+
+    $('#btn-bill-showall').click(function() {
+        $('#bill_table tbody tr').show(200);
+    });
 
     var highlight_owers = function(){
         var ower_ids = $(this).attr("owers").split(',');
@@ -99,6 +112,20 @@
 
     {% if bills.count() > 0 %}
         <div class="clearfix"></div>
+
+        <div id="bill-search">
+            <span>Search by:</span>
+            <form class="form-inline mt-2">
+                <div class="form-group mr-sm-2">
+                    <label for="payer-select" class="mr-sm-2">{{ _("Payer") }}</label>
+                    {{ bill_form.payer(id="payer-search-select", class="form-control custom-select", placeholder='') | safe }}
+                </div>
+                <div class="form-group">
+                    <button id="btn-bill-search" type="button" class="btn btn-secondary mr-sm-2">{{ _("Search") }}</button>
+                    <button id="btn-bill-showall" type="button" class="btn btn-secondary">{{ _("Show All") }}</button>
+                </div>
+            </form>
+        </div>
 
         <table id="bill_table" class="col table table-striped table-hover table-responsive-sm">
             <thead><tr><th>{{ _("When?") }}</th><th>{{ _("Who paid?") }}</<th><th>{{ _("For what?") }}</th><th>{{ _("For whom?") }}</th><th>{{ _("How much?") }}</th><th>{{ _("Actions") }}</th></tr></thead>


### PR DESCRIPTION
A small feature addition, added search bar to bill list allowing searching/filter by payer. Hide/shows bill table rows on the frontend using jQuery `filter()`. There are minor Bootstrap alignment issues when viewport gets too small (specifically, when the Add a new bill button gets pushed over), but otherwise it should work as intended. Please review and let me know if there are any issues (e.g. if some of the logic needs to be moved around, or macroed). If the current work passes, I will keep working and add additional filter options.

This was a good opportunity to learn Flask :smiley:. #430 