### PR TITLE
Fix language code parsing

### DIFF
--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -97,7 +97,7 @@ def static_include(filename):
 
 
 def locale_from_iso(iso_code):
-    return Locale(iso_code)
+    return Locale.parse(iso_code)
 
 
 def list_of_dicts2json(dict_to_convert):


### PR DESCRIPTION
Currently, norwegian (nb_NO) displays as "None" in the language change
select (upper right corner of the UI).

This is because language codes were not parsed correctly when they contain "_".

Here is a summary of the changes for the languages we support, before:

```
>>> Locale('nb_NO')
Locale('nb_NO')
>>> Locale('nb_NO').display_name
None

>>> Locale('es_419')
Locale('es', territory='419')
>>> Locale('es_419').display_name
'español latinoamericano'

>>> Locale('zh_HANS-CN')
babel.core.UnknownLocaleError: unknown locale 'zh_HANS-CN'
>>> Locale('zh_HANS-CN').display_name
babel.core.UnknownLocaleError: unknown locale 'zh_HANS-CN'
```

After:

```
>>> Locale.parse('nb_NO')
Locale('nb', territory='NO')
>>> Locale.parse('nb_NO').display_name
'norsk bokmål (Norge)'

>>> Locale.parse('es_419')
Locale('es', territory='419')
>>> Locale.parse('es_419').display_name
'español (Latinoamérica)'

>>> Locale.parse('zh_HANS-CN')
Locale('zh', script='Hans')
>>> Locale.parse('zh_HANS-CN').display_name
'中文 (简体)'
```

Summary: it fixes support for Norwegian and Chinese, and slightly changes
the display string for es_419.