### PR TITLE
Localize dates and times

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,6 +31,7 @@ connection string. This will look like::
 
     SQLALCHEMY_DATABASE_URI = 'postgresql://myuser:mypass@localhost/dbname?client_encoding=utf8'
 
+.. _the SQLAlchemy documentation: http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 
 `SECRET_KEY`
 ------------
@@ -96,7 +97,26 @@ if set to ``"somestring"``, it will be served from a "folder"
 
 - **Default value:** ``""`` (empty string)
 
-.. _the SQLAlchemy documentation: http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
+`BABEL_DEFAULT_TIMEZONE`
+------------------------
+
+The timezone that will be used to convert date and time when displaying them
+to the user (all times are always stored in UTC internally).
+If not set, it will default to the timezone configured on the Operating System
+of the server running ihatemoney, which may or may not be what you want.
+
+- **Default value:** *unset* (use the timezone of the server Operating System)
+- **Production value:** Set to the timezone of your expected users, with a
+  format such as ``"Europe/Paris"``. See `this list of TZ database names`_
+  for a complete list.
+
+Note: this setting is actually interpreted by Flask-Babel, see the
+`Flask-Babel guide for formatting dates`_ for details.
+
+.. _this list of TZ database name: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+
+.. _Flask-Babel guide for formatting dates: https://pythonhosted.org/Flask-Babel/#formatting-dates
+
 
 Configuring emails sending
 --------------------------

--- a/ihatemoney/conf-templates/ihatemoney.cfg.j2
+++ b/ihatemoney/conf-templates/ihatemoney.cfg.j2
@@ -34,3 +34,7 @@ ALLOW_PUBLIC_PROJECT_CREATION = True
 
 # If set to True, an administration dashboard is available.
 ACTIVATE_ADMIN_DASHBOARD = False
+
+# You can change the timezone used to display time.  By default it will be
+#derived from the server OS.
+#BABEL_DEFAULT_TIMEZONE = "Europe/Paris"

--- a/ihatemoney/history.py
+++ b/ihatemoney/history.py
@@ -82,7 +82,7 @@ def get_history(project, human_readable_names=True):
                 object_str = describe_version(version)
 
             common_properties = {
-                "time": version.transaction.issued_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "time": version.transaction.issued_at,
                 "operation_type": version.operation_type,
                 "object_type": object_type,
                 "object_desc": object_str,

--- a/ihatemoney/run.py
+++ b/ihatemoney/run.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import warnings
 
+from babel.dates import LOCALTZ
 from flask import Flask, g, render_template, request, session
 from flask_babel import Babel
 from flask_mail import Mail
@@ -146,8 +147,10 @@ def create_app(
     app.jinja_env.globals["locale_from_iso"] = locale_from_iso
     app.jinja_env.filters["minimal_round"] = minimal_round
 
-    # Translations
-    babel = Babel(app)
+    # Translations and time zone (used to display dates).  The timezone is
+    # taken from the BABEL_DEFAULT_TIMEZONE settings, and falls back to
+    # the local timezone of the server OS by using LOCALTZ.
+    babel = Babel(app, default_timezone=str(LOCALTZ))
 
     @babel.localeselector
     def get_locale():

--- a/ihatemoney/templates/history.html
+++ b/ihatemoney/templates/history.html
@@ -177,7 +177,7 @@
     <tbody>
     {% for event in history %}
     <tr>
-            <td><script>document.write(localizeTime("{{ event.time }}"));</script></td>
+            <td>{{ event.time|datetimeformat("medium") }}</td>
             <td >
                 <div class="history_icon">
                     <i {% if event.operation_type == OperationType.INSERT  %}

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -117,7 +117,7 @@
         <tr owers="{{bill.owers|join(',','id')}}" payer="{{bill.payer.id}}">
                 <td>
                     <span data-toggle="tooltip" data-placement="top"
-                        title="{{ _('Added on %(date)s', date=bill.creation_date if bill.creation_date else bill.date) }}">
+                        title="{{ _('Added on %(date)s', date=bill.creation_date|dateformat("long") if bill.creation_date else bill.date|dateformat("long")) }}">
                         {{ bill.date }}
                     </span>
                 </td>


### PR DESCRIPTION
See individual commits for details.

I'm not sure about this one. On the one hand, having localized date and time that follows the selected language is nice. On the other hand, the timezone issue (see 812efad22a9d3a07699feec681fccce52acc5442) means that it would make more sense to format date and time in Javascript, but then we would have less control over the formatting and it won't follow the selected language.