### PR TITLE
Add support for different categories of "flash alerts"

### DIFF
--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -125,9 +125,13 @@
   </div>
 
   <div class="messages">
-      {% for message in get_flashed_messages() %}
-      <div class="flash alert alert-success">{{ message }}</div>
-      {% endfor %}
+    {% for category, message in get_flashed_messages(with_categories=true) %}
+      {% if category == "message" %}{# Default category for flash(msg) #}
+        <div class="flash alert alert-success">{{ message }}</div>
+      {% else %}
+        <div class="flash alert alert-{{ category }}">{{ message }}</div>
+      {% endif %}
+    {% endfor %}
   </div>
 
   {% block footer %}

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -309,19 +309,10 @@ def create_project():
             try:
                 current_app.mail.send(msg)
             except SMTPRecipientsRefused:
-                msg_compl = "Problem sending mail. "
-                # TODO: destroy the project and cancel instead?
-            else:
-                msg_compl = ""
+                flash(_("Error while sending reminder email"), category="danger")
 
             # redirect the user to the next step (invite)
-            flash(
-                _(
-                    "%(msg_compl)sThe project identifier is %(project)s",
-                    msg_compl=msg_compl,
-                    project=project.id,
-                )
-            )
+            flash(_("The project identifier is %(project)s", project=project.id))
             return redirect(url_for(".list_bills", project_id=project.id))
 
     return render_template("create_project.html", form=form)
@@ -393,7 +384,7 @@ def edit_project():
 
             return redirect(url_for("main.list_bills"))
         except ValueError:
-            flash(_("Invalid JSON"), category="error")
+            flash(_("Invalid JSON"), category="danger")
 
     # Edit form
     if edit_form.validate_on_submit():


### PR DESCRIPTION
It is now possible to specify a category when calling `flash()` to change
the color of the alert box.  The default category is interpreted as
"success" for backwards compatibility.  For now, we only use the
additional "danger" category to show errors.

The available categories are the Bootstrap contextual classes listed here:

  https://getbootstrap.com/docs/4.0/components/alerts/