### PR TITLE
Improve error handling when sending emails

### DIFF
--- a/ihatemoney/messages.pot
+++ b/ihatemoney/messages.pot
@@ -157,11 +157,22 @@ msgstr ""
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr ""
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -190,6 +201,12 @@ msgid "You have been invited to share your expenses for %(project)s"
 msgstr ""
 
 msgid "Your invitations have been sent"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
 msgstr ""
 
 #, python-format

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -51,10 +51,10 @@ class BaseTestCase(TestCase):
             follow_redirects=True,
         )
 
-    def post_project(self, name):
+    def post_project(self, name, follow_redirects=False):
         """Create a fake project"""
         # create the project
-        self.client.post(
+        return self.client.post(
             "/create",
             data={
                 "name": name,
@@ -63,6 +63,7 @@ class BaseTestCase(TestCase):
                 "contact_email": f"{name}@notmyidea.org",
                 "default_currency": "USD",
             },
+            follow_redirects=follow_redirects,
         )
 
     def create_project(self, name):

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -53,7 +53,7 @@ class BaseTestCase(TestCase):
             follow_redirects=True,
         )
 
-    def post_project(self, name, follow_redirects=False):
+    def post_project(self, name, follow_redirects=True):
         """Create a fake project"""
         # create the project
         return self.client.post(

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -2296,13 +2296,13 @@ class EmailFailureTestCase(IhatemoneyTestCase):
         with patch.object(
             self.app.mail, "send", MagicMock(side_effect=smtplib.SMTPException)
         ):
-            resp = self.post_project("raclette", follow_redirects=True)
+            resp = self.post_project("raclette")
         # Check that an error message is displayed
         self.assertIn(
             "We tried to send you an reminder email, but there was an error",
             resp.data.decode("utf-8"),
         )
-        # Check that we are redirected anyway
+        # Check that we were redirected to the home page anyway
         self.assertIn(
             'You probably want to <a href="/raclette/members/add"',
             resp.data.decode("utf-8"),
@@ -2311,13 +2311,13 @@ class EmailFailureTestCase(IhatemoneyTestCase):
     def test_creation_email_failure_socket(self):
         self.login("raclette")
         with patch.object(self.app.mail, "send", MagicMock(side_effect=socket.error)):
-            resp = self.post_project("raclette", follow_redirects=True)
+            resp = self.post_project("raclette")
         # Check that an error message is displayed
         self.assertIn(
             "We tried to send you an reminder email, but there was an error",
             resp.data.decode("utf-8"),
         )
-        # Check that we are redirected anyway
+        # Check that we were redirected to the home page anyway
         self.assertIn(
             'You probably want to <a href="/raclette/members/add"',
             resp.data.decode("utf-8"),

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -5,6 +5,8 @@ import io
 import json
 import os
 import re
+import smtplib
+import socket
 from time import sleep
 import unittest
 from unittest.mock import MagicMock, patch
@@ -2286,6 +2288,78 @@ class ModelsTestCase(IhatemoneyTestCase):
             if bill.what == "delicatessen":
                 pay_each_expected = 10 / 3
                 self.assertEqual(bill.pay_each(), pay_each_expected)
+
+
+class EmailFailureTestCase(IhatemoneyTestCase):
+    def test_creation_email_failure_smtp(self):
+        self.login("raclette")
+        with patch.object(
+            self.app.mail, "send", MagicMock(side_effect=smtplib.SMTPException)
+        ):
+            resp = self.post_project("raclette", follow_redirects=True)
+        # Check that an error message is displayed
+        self.assertIn(
+            "We tried to send you an reminder email, but there was an error",
+            resp.data.decode("utf-8"),
+        )
+        # Check that we are redirected anyway
+        self.assertIn(
+            'You probably want to <a href="/raclette/members/add"',
+            resp.data.decode("utf-8"),
+        )
+
+    def test_creation_email_failure_socket(self):
+        self.login("raclette")
+        with patch.object(self.app.mail, "send", MagicMock(side_effect=socket.error)):
+            resp = self.post_project("raclette", follow_redirects=True)
+        # Check that an error message is displayed
+        self.assertIn(
+            "We tried to send you an reminder email, but there was an error",
+            resp.data.decode("utf-8"),
+        )
+        # Check that we are redirected anyway
+        self.assertIn(
+            'You probably want to <a href="/raclette/members/add"',
+            resp.data.decode("utf-8"),
+        )
+
+    def test_password_reset_email_failure(self):
+        self.create_project("raclette")
+        for exception in (smtplib.SMTPException, socket.error):
+            with patch.object(self.app.mail, "send", MagicMock(side_effect=exception)):
+                resp = self.client.post(
+                    "/password-reminder", data={"id": "raclette"}, follow_redirects=True
+                )
+            # Check that an error message is displayed
+            self.assertIn(
+                "there was an error while sending you an email",
+                resp.data.decode("utf-8"),
+            )
+            # Check that we were not redirected to the success page
+            self.assertNotIn(
+                "A link to reset your password has been sent to you",
+                resp.data.decode("utf-8"),
+            )
+
+    def test_invitation_email_failure(self):
+        self.login("raclette")
+        self.post_project("raclette")
+        for exception in (smtplib.SMTPException, socket.error):
+            with patch.object(self.app.mail, "send", MagicMock(side_effect=exception)):
+                resp = self.client.post(
+                    "/raclette/invite",
+                    data={"emails": "toto@notmyidea.org"},
+                    follow_redirects=True,
+                )
+            # Check that an error message is displayed
+            self.assertIn(
+                "there was an error while trying to send the invitation emails",
+                resp.data.decode("utf-8"),
+            )
+            # Check that we are still on the same page (no redirection)
+            self.assertIn(
+                "Invite people to join this project", resp.data.decode("utf-8"),
+            )
 
 
 def em_surround(string, regex_escape=False):

--- a/ihatemoney/translations/cs/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/cs/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: cs\n"
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -173,11 +173,22 @@ msgstr ""
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr ""
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -206,6 +217,12 @@ msgid "You have been invited to share your expenses for %(project)s"
 msgstr ""
 
 msgid "Your invitations have been sent"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
 msgstr ""
 
 #, python-format
@@ -755,5 +772,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "each"
+#~ msgstr ""
+
+#~ msgid "Error while sending reminder email"
 #~ msgstr ""
 

--- a/ihatemoney/translations/de/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-02-12 10:50+0000\n"
 "Last-Translator: flolilo <flolilo@mailbox.org>\n"
 "Language: de\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -182,11 +182,22 @@ msgstr ""
 "Du hast gerade das Projekt '%(project)s' erstellt, um deine Ausgaben zu "
 "teilen"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -216,6 +227,12 @@ msgstr "Du wurdest eingeladen, deine Ausgaben für %(project)s zu teilen"
 
 msgid "Your invitations have been sent"
 msgstr "Deine Einladungen wurden versendet"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -784,4 +801,7 @@ msgstr ""
 
 #~ msgid "each"
 #~ msgstr "alles"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/el/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/el/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: el\n"
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -173,11 +173,22 @@ msgstr ""
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr ""
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -206,6 +217,12 @@ msgid "You have been invited to share your expenses for %(project)s"
 msgstr ""
 
 msgid "Your invitations have been sent"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
 msgstr ""
 
 #, python-format
@@ -755,5 +772,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "each"
+#~ msgstr ""
+
+#~ msgid "Error while sending reminder email"
 #~ msgstr ""
 

--- a/ihatemoney/translations/es_419/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/es_419/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-05-03 15:20+0000\n"
 "Last-Translator: Fabian Rodriguez <fabian@fabianrodriguez.com>\n"
 "Language: es_419\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -182,11 +182,22 @@ msgstr "Este código privado no es el correcto"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Acabas de crear '%(project)s' para compartir tus gastos"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -216,6 +227,12 @@ msgstr "Usted ha sido invitado a compartir sus gastos para %(project)s"
 
 msgid "Your invitations have been sent"
 msgstr "Sus invitaciones han sido enviadas"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -805,4 +822,7 @@ msgstr "Período"
 
 #~ msgid "each"
 #~ msgstr "Cada"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/fr/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/fr/LC_MESSAGES/messages.po
@@ -7,18 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-05-15 20:41+0000\n"
 "Last-Translator: Glandos <bugs-github@antipoul.fr>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/i-hate-money/"
-"i-hate-money/fr/>\n"
 "Language: fr\n"
+"Language-Team: French <https://hosted.weblate.org/projects/i-hate-money/i"
+"-hate-money/fr/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.1-dev\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -185,12 +184,23 @@ msgstr "Le code que vous avez entré n’est pas correct"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Vous venez de créer « %(project)s » pour partager vos dépenses"
 
-msgid "Error while sending reminder email"
-msgstr "Erreur lors de l’envoi du courriel de rappel"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
+msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
 msgstr "L’identifiant de ce projet est %(project)s"
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
+msgstr ""
 
 msgid "No token provided"
 msgstr "Aucun token n’a été fourni"
@@ -219,6 +229,12 @@ msgstr "Vous avez été invité à partager vos dépenses pour %(project)s"
 
 msgid "Your invitations have been sent"
 msgstr "Vos invitations ont bien été envoyées"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -1019,3 +1035,7 @@ msgstr "Période"
 
 #~ msgid "each"
 #~ msgstr "chacun"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr "Erreur lors de l’envoi du courriel de rappel"
+

--- a/ihatemoney/translations/id/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/id/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2019-11-16 10:04+0000\n"
 "Last-Translator: Muhammad Fauzi <fauzi.padlaw@gmail.com>\n"
 "Language: id\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -178,11 +178,22 @@ msgstr "Kode pribadi ini tidak benar"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Anda baru saja membuat %(project)s untuk membagikan harga Anda"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -212,6 +223,12 @@ msgstr "Anda telah diundang untuk membagikan harga Anda untuk %(project)s"
 
 msgid "Your invitations have been sent"
 msgstr "Undangan Anda telah dikirim"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -784,4 +801,7 @@ msgstr ""
 
 #~ msgid "each"
 #~ msgstr "setiap"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/it/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/it/LC_MESSAGES/messages.po
@@ -1,19 +1,19 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-05-18 13:02+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/i-hate-money/"
-"i-hate-money/it/>\n"
 "Language: it\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/i-hate-"
+"money/i-hate-money/it/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.1-dev\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -167,12 +167,13 @@ msgstr "Troppi tentativi di accesso non riusciti. Riprova più tardi."
 #, python-format
 msgid "This admin password is not the right one. Only %(num)d attempts left."
 msgstr ""
-"Questa password di amministrazione non è corretta. Solo %(num)d tentativi "
-"rimasti."
+"Questa password di amministrazione non è corretta. Solo %(num)d tentativi"
+" rimasti."
 
 msgid "You either provided a bad token or no project identifier."
 msgstr ""
-"Hai fornito un token invalido o l'identificatore del progetto non è valido."
+"Hai fornito un token invalido o l'identificatore del progetto non è "
+"valido."
 
 msgid "This private code is not the right one"
 msgstr "Questo codice privato non è quello corretto"
@@ -181,12 +182,23 @@ msgstr "Questo codice privato non è quello corretto"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Hai appena creato '%(project)s' per condividere le tue spese"
 
-msgid "Error while sending reminder email"
-msgstr "Errore durante l'invio dell'email di promemoria"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
+msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
 msgstr "L'identificatore del progetto è %(project)s"
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
+msgstr ""
 
 msgid "No token provided"
 msgstr "Nessun token fornito"
@@ -215,6 +227,12 @@ msgstr "Sei stato invitato a condividere le tue spese per %(project)s"
 
 msgid "Your invitations have been sent"
 msgstr "I tuoi inviti sono stati spediti"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -764,3 +782,7 @@ msgstr ""
 
 #~ msgid "each"
 #~ msgstr ""
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr "Errore durante l'invio dell'email di promemoria"
+

--- a/ihatemoney/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/nb_NO/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2019-11-12 09:04+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language: nb_NO\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -182,11 +182,22 @@ msgstr "Denne private koden er ikke rett"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Du har akkurat opprettet \"%(project)s\" for å dele dine utgifter"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -220,6 +231,12 @@ msgstr ""
 
 msgid "Your invitations have been sent"
 msgstr "Invitasjonene dine har blitt sendt"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -915,4 +932,7 @@ msgstr ""
 
 #~ msgid "each"
 #~ msgstr "hver"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/nl/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/nl/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2019-10-07 22:56+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language: nl\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -176,11 +176,22 @@ msgstr ""
 "Je hebt zojuist het project '%(project)s' aangemaakt om je uitgaven te "
 "verdelen"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -210,6 +221,12 @@ msgstr "Je bent uitgenodigd om je uitgaven te delen met %(project)s"
 
 msgid "Your invitations have been sent"
 msgstr "Je uitnodigingen zijn verstuurd"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -773,4 +790,7 @@ msgstr ""
 
 #~ msgid "each"
 #~ msgstr "per persoon"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/pl/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/pl/LC_MESSAGES/messages.po
@@ -1,20 +1,20 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-05-13 15:41+0000\n"
 "Last-Translator: Szylu <chipolade@gmail.com>\n"
-"Language-Team: Polish <https://hosted.weblate.org/projects/i-hate-money/"
-"i-hate-money/pl/>\n"
 "Language: pl\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/i-hate-money/i"
+"-hate-money/pl/>\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.1-dev\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -179,12 +179,23 @@ msgstr "Ten prywatny kod jest niewłaściwy"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Właśnie utworzyłeś „%(project)s”, aby podzielić się wydatkami"
 
-msgid "Error while sending reminder email"
-msgstr "Błąd podczas wysyłania wiadomości e-mail z przypomnieniem"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
+msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
 msgstr "Identyfikator projektu to %(project)s"
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
+msgstr ""
 
 msgid "No token provided"
 msgstr "Nie podano tokena"
@@ -213,6 +224,12 @@ msgstr "Zostałeś zaproszony do podzielenia się swoimi wydatkami w %(project)s
 
 msgid "Your invitations have been sent"
 msgstr "Twoje zaproszenia zostały wysłane"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -799,3 +816,7 @@ msgstr "Okres"
 
 #~ msgid "each"
 #~ msgstr "każdy"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr "Błąd podczas wysyłania wiadomości e-mail z przypomnieniem"
+

--- a/ihatemoney/translations/ru/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/ru/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-04-28 07:11+0000\n"
 "Last-Translator: Vsevolod <sevauserg.com@gmail.com>\n"
 "Language: ru\n"
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -181,11 +181,22 @@ msgstr "Этот приватный код не подходит"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "Вы только что создали '%(project)s' , чтобы разделить расходы"
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -215,6 +226,12 @@ msgstr "Вас пригласили разделить расходы в про�
 
 msgid "Your invitations have been sent"
 msgstr "Ваш код приглашения был отправлен"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -794,4 +811,7 @@ msgstr "Период"
 
 #~ msgid "each"
 #~ msgstr "каждый"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr ""
 

--- a/ihatemoney/translations/tr/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/tr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2019-08-07 13:24+0000\n"
 "Last-Translator: Mesut Akcan <makcan@gmail.com>\n"
 "Language: tr\n"
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -178,11 +178,22 @@ msgstr ""
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr ""
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -211,6 +222,12 @@ msgid "You have been invited to share your expenses for %(project)s"
 msgstr ""
 
 msgid "Your invitations have been sent"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
 msgstr ""
 
 #, python-format
@@ -760,5 +777,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "each"
+#~ msgstr ""
+
+#~ msgid "Error while sending reminder email"
 #~ msgstr ""
 

--- a/ihatemoney/translations/uk/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/uk/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2019-12-08 16:26+0000\n"
 "Last-Translator: Tymofij Lytvynenko <till.svit@gmail.com>\n"
 "Language: uk\n"
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -175,11 +175,22 @@ msgstr ""
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr ""
 
-msgid "Error while sending reminder email"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
 msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
 msgstr ""
 
 msgid "No token provided"
@@ -208,6 +219,12 @@ msgid "You have been invited to share your expenses for %(project)s"
 msgstr ""
 
 msgid "Your invitations have been sent"
+msgstr ""
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
 msgstr ""
 
 #, python-format
@@ -757,5 +774,8 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "each"
+#~ msgstr ""
+
+#~ msgid "Error while sending reminder email"
 #~ msgstr ""
 

--- a/ihatemoney/translations/zh_HANS-CN/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/zh_HANS-CN/LC_MESSAGES/messages.po
@@ -1,19 +1,20 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 21:41+0200\n"
+"POT-Creation-Date: 2020-05-18 15:11+0200\n"
 "PO-Revision-Date: 2020-05-13 15:41+0000\n"
 "Last-Translator: Muge Niu <mugeniu12138@gmail.com>\n"
-"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
-"i-hate-money/i-hate-money/zh_Hans/>\n"
-"Language: zh_HANS-CN\n"
+"Language: zh_HANS_CN\n"
+"Language-Team: Chinese (Simplified) "
+"<https://hosted.weblate.org/projects/i-hate-money/i-hate-money/zh_Hans/>"
+"\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.1-dev\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid ""
 "Not a valid amount or expression. Only numbers and + - * / operators are "
@@ -174,12 +175,23 @@ msgstr "专用码不正确"
 msgid "You have just created '%(project)s' to share your expenses"
 msgstr "你新建了一个‘%(project)s'来分担你的花费"
 
-msgid "Error while sending reminder email"
-msgstr "发送提醒邮件时出错"
+msgid "A reminder email has just been sent to you"
+msgstr ""
+
+msgid ""
+"We tried to send you an reminder email, but there was an error. You can "
+"still use the project normally."
+msgstr ""
 
 #, python-format
 msgid "The project identifier is %(project)s"
 msgstr "项目的标识符是%(project)s"
+
+msgid ""
+"Sorry, there was an error while sending you an email with password reset "
+"instructions. Please check the email configuration of the server or "
+"contact the administrator."
+msgstr ""
 
 msgid "No token provided"
 msgstr "没有符号"
@@ -208,6 +220,12 @@ msgstr "你被邀请进入 %(project)s来分担你的花费"
 
 msgid "Your invitations have been sent"
 msgstr "你的申请已发出"
+
+msgid ""
+"Sorry, there was an error while trying to send the invitation emails. "
+"Please check the email configuration of the server or contact the "
+"administrator."
+msgstr ""
 
 #, python-format
 msgid "%(member)s has been added"
@@ -771,3 +789,7 @@ msgstr "期间"
 
 #~ msgid "each"
 #~ msgstr "每一个·"
+
+#~ msgid "Error while sending reminder email"
+#~ msgstr "发送提醒邮件时出错"
+

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -12,7 +12,7 @@ import socket
 
 from babel import Locale
 from babel.numbers import get_currency_name, get_currency_symbol
-from flask import current_app, flash, redirect, render_template
+from flask import current_app, redirect, render_template
 from flask_babel import get_locale, lazy_gettext as _
 import jinja2
 from werkzeug.routing import HTTPException, RoutingException
@@ -30,12 +30,10 @@ def slugify(value):
     return re.sub(r"[-\s]+", "-", value)
 
 
-def send_email(mail_message, flash_success="", flash_error=""):
-    """Send an email using Flask-Mail, returning False if there was an error.
+def send_email(mail_message):
+    """Send an email using Flask-Mail, with proper error handling.
 
-    Optionally display a "flash alert" message to the user.  The flash
-    message is different depending on whether we could successfully send
-    the email or not.
+    Return True if everything went well, and False if there was an error.
     """
     # Since Python 3.4, SMTPException and socket.error are actually
     # identical, but this was not the case before.  Also, it is more clear
@@ -43,12 +41,8 @@ def send_email(mail_message, flash_success="", flash_error=""):
     try:
         current_app.mail.send(mail_message)
     except (smtplib.SMTPException, socket.error):
-        if flash_error:
-            flash(flash_error, category="danger")
         return False
     # Email was sent successfully
-    if flash_success:
-        flash(flash_success, category="success")
     return True
 
 

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -341,7 +341,7 @@ def remind_password():
             )
             success = send_email(
                 remind_message,
-                _("A password reminder email has just been sent to you"),
+                "",
                 _(
                     "Sorry, there was an error while sending you an email with password reset instructions. "
                     "Please check the email configuration of the server or contact the administrator."

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -308,8 +308,12 @@ def create_project():
             msg = Message(
                 message_title, body=message_body, recipients=[project.contact_email]
             )
-            success = send_email(msg, _("A reminder email has just been sent to you"))
-            if not success:
+            success = send_email(msg)
+            if success:
+                flash(
+                    _("A reminder email has just been sent to you"), category="success"
+                )
+            else:
                 # Display the error as a simple "info" alert, because it's
                 # not critical and doesn't prevent using the project.
                 flash(
@@ -339,19 +343,20 @@ def remind_password():
                 body=render_localized_template("password_reminder", project=project),
                 recipients=[project.contact_email],
             )
-            success = send_email(
-                remind_message,
-                "",
-                _(
-                    "Sorry, there was an error while sending you an email "
-                    "with password reset instructions. "
-                    "Please check the email configuration of the server "
-                    "or contact the administrator."
-                ),
-            )
+            success = send_email(remind_message)
             if success:
                 return redirect(url_for(".password_reminder_sent"))
-
+            else:
+                flash(
+                    _(
+                        "Sorry, there was an error while sending you an email "
+                        "with password reset instructions. "
+                        "Please check the email configuration of the server "
+                        "or contact the administrator."
+                    ),
+                    category="danger",
+                )
+                # Fall-through: we stay on the same page and display the form again
     return render_template("password_reminder.html", form=form)
 
 
@@ -598,18 +603,20 @@ def invite():
                 body=message_body,
                 recipients=[email.strip() for email in form.emails.data.split(",")],
             )
-            success = send_email(
-                msg,
-                _("Your invitations have been sent"),
-                _(
-                    "Sorry, there was an error while trying to send the invitation emails. "
-                    "Please check the email configuration of the server "
-                    "or contact the administrator."
-                ),
-            )
+            success = send_email(msg)
             if success:
+                flash(_("Your invitations have been sent"), category="success")
                 return redirect(url_for(".list_bills"))
-
+            else:
+                flash(
+                    _(
+                        "Sorry, there was an error while trying to send the invitation emails. "
+                        "Please check the email configuration of the server "
+                        "or contact the administrator."
+                    ),
+                    category="danger",
+                )
+                # Fall-through: we stay on the same page and display the form again
     return render_template("send_invites.html", form=form)
 
 

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -343,8 +343,10 @@ def remind_password():
                 remind_message,
                 "",
                 _(
-                    "Sorry, there was an error while sending you an email with password reset instructions. "
-                    "Please check the email configuration of the server or contact the administrator."
+                    "Sorry, there was an error while sending you an email "
+                    "with password reset instructions. "
+                    "Please check the email configuration of the server "
+                    "or contact the administrator."
                 ),
             )
             if success:
@@ -601,7 +603,8 @@ def invite():
                 _("Your invitations have been sent"),
                 _(
                     "Sorry, there was an error while trying to send the invitation emails. "
-                    "Please check the email configuration of the server or contact the administrator."
+                    "Please check the email configuration of the server "
+                    "or contact the administrator."
                 ),
             )
             if success:


### PR DESCRIPTION
In one case, we were not catching a family of possible exceptions
(socket.error), and in the two other cases there was no error handling at
all.  Sending emails can easily fail if no email server is configured, so
it is really necessary to handle these errors instead of crashing with a
HTTP 500 error.

Refactor email sending code and add proper error handling.

Show alert messages that tell the user if an email was sent or if there
was an error.

When sending a password reminder email or inviting people by email, we
don't proceed to the next step in case of error, because sending emails is
the whole point of these actions.