### PR TITLE
use currency format everywhere

### DIFF
--- a/ihatemoney/templates/settle_bills.html
+++ b/ihatemoney/templates/settle_bills.html
@@ -25,7 +25,7 @@
     <tr receiver={{bill.receiver.id}}>
             <td>{{ bill.ower }}</td>
             <td>{{ bill.receiver }}</td>
-            <td>{{ "%0.2f"|format(bill.amount) }}</td>
+            <td>{{ bill.amount|currencyformat_nc(g.project.default_currency) }}</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/ihatemoney/templates/statistics.html
+++ b/ihatemoney/templates/statistics.html
@@ -30,8 +30,8 @@
         {% for stat in members_stats|sort(attribute='member.name') %}
         <tr>
             <td class="d-md-none">{{ stat.member.name }}</td>
-            <td>{{ "%0.2f"|format(stat.paid) }}</td>
-            <td>{{ "%0.2f"|format(stat.spent) }}</td>
+            <td>{{ stat.paid|currencyformat_nc(g.project.default_currency) }}</td>
+            <td>{{ stat.spent|currencyformat_nc(g.project.default_currency) }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -43,7 +43,7 @@
         {% for month in months %}
                 <tr>
                     <td>{{ _(month.strftime("%B")) }} {{ month.year }}</td>
-                    <td>{{ "%0.2f"|format(monthly_stats[month.year][month.month]) }}</td>
+                    <td>{{ monthly_stats[month.year][month.month]|currencyformat_nc(g.project.default_currency) }}</td>
                 </tr>
         {% endfor %}
         </tbody>

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -942,16 +942,18 @@ class BudgetTestCase(IhatemoneyTestCase):
         response = self.client.get("/raclette/statistics")
         regex = r"<td class=\"d-md-none\">{}</td>\s+<td>{}</td>\s+<td>{}</td>"
         self.assertRegex(
-            response.data.decode("utf-8"), regex.format("zorglub", "20.00", "31.67"),
+            response.data.decode("utf-8"),
+            regex.format("zorglub", r"\$20\.00", r"\$31\.67"),
         )
         self.assertRegex(
-            response.data.decode("utf-8"), regex.format("fred", "20.00", "5.83"),
+            response.data.decode("utf-8"),
+            regex.format("fred", r"\$20\.00", r"\$5\.83"),
         )
         self.assertRegex(
-            response.data.decode("utf-8"), regex.format("tata", "0.00", "2.50"),
+            response.data.decode("utf-8"), regex.format("tata", r"\$0\.00", r"\$2\.50"),
         )
         self.assertRegex(
-            response.data.decode("utf-8"), regex.format("pépé", "0.00", "0.00"),
+            response.data.decode("utf-8"), regex.format("pépé", r"\$0\.00", r"\$0\.00"),
         )
 
         # Check that the order of participants in the sidebar table is the


### PR DESCRIPTION
This should unify the number formats, along with #618