### PR TITLE
Changed @media max-width for .home .card to 450px to fix responsiveness

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -162,7 +162,7 @@ body {
   margin-bottom: 20px;
   margin-left: 25px;
 }
-@media (max-width: 400px) {
+@media (max-width: 450px) {
   .home .card {
     min-width: unset;
   }


### PR DESCRIPTION
I noticed on my iphone 6 that the card divs for the login forms were not central on the screen. It seems to be fixed by increasing the @media max width.

before:
![before change](https://user-images.githubusercontent.com/56972576/87704718-b55bc900-c794-11ea-8dfd-ba7f0e387d6b.png)

after:
![after change](https://user-images.githubusercontent.com/56972576/87704754-c4427b80-c794-11ea-9855-42bcafb1dd0f.png)

