### PR TITLE
Update apache-vhost config generation

### DIFF
--- a/ihatemoney/conf-templates/apache-vhost.conf.j2
+++ b/ihatemoney/conf-templates/apache-vhost.conf.j2
@@ -11,8 +11,7 @@
     <Directory {{ pkg_path }}>
        WSGIProcessGroup ihatemoney
        WSGIApplicationGroup %{GLOBAL}
-       Order deny,allow
-       Allow from all
+       Require all granted
     </Directory>
 
     Alias /static/ {{ pkg_path }}/static/


### PR DESCRIPTION
The current configuration generated uses the old syntax for Apache access control. On a Debian 10 install I recently did the generated config just resulted in an access denied error when using Apache and mod_wsgi. Making the changes in this pull request to my Apache config solved the issue (got the hint looking at Flask's documentation here: https://flask.palletsprojects.com/en/1.1.x/deploying/mod_wsgi/#configuring-apache).