### PR TITLE
Add Japanese to the supported languages

### DIFF
--- a/ihatemoney/default_settings.py
+++ b/ihatemoney/default_settings.py
@@ -24,4 +24,5 @@ SUPPORTED_LANGUAGES = [
     "tr",
     "uk",
     "zh_Hans",
+    "ja",
 ]


### PR DESCRIPTION
Hi
I've just finished the translation into Japanese on Weblate,[https://hosted.weblate.org/projects/i-hate-money/i-hate-money/](url)
So I updated default_settings.py to add Japanese as one of the supported languages.