### PR TITLE
Add python3.9 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ encouraged to do so.
 Requirements
 ============
 
-* **Python**: 3.6, 3.7, 3.8.
+* **Python**: version 3.6 to 3.9.
 * **Backends**: MySQL, PostgreSQL, SQLite, Memory.
 
 Contributing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Requirements
 
 «Ihatemoney» depends on:
 
-* **Python**: either 3.6, 3.7 or 3.8 will work.
+* **Python**: version 3.6 to 3.9 included will work.
 * **A Backend**: to choose among MySQL, PostgreSQL, SQLite or Memory.
 * **Virtual environment** (recommended): `python3-venv` package under Debian/Ubuntu.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: WSGI :: Application
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py37,py36,docs,flake8,black
+envlist = py39,py38,py37,py36,docs,flake8,black
 skip_missing_interpreters = True
 
 [testenv]
@@ -42,3 +42,4 @@ python =
   3.6: py36
   3.7: py37
   3.8: py38, docs, black, flake8
+  3.9: py39


### PR DESCRIPTION
Still use 3.8 for extensive tests.