### PR TITLE
Fix travis build with python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ python:
   - "3.9"
 script: tox
 install:
+  - pip install --upgrade pip
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ script: tox
 before_install:
   - python -m pip install --upgrade pip
 install:
+  - pip --version
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.9"
 script: tox
 before_install:
-  - python -m pip install --upgrade pip
+  - python -m pip install --upgrade pip virtualenv
 install:
-  - pip --version
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.8"
   - "3.9"
 script: tox
+before_install:
+  - python -m pip install --upgrade pip
 install:
-  - pip install --upgrade pip
   - pip install tox-travis


### PR DESCRIPTION
Some dependencies (cryptography / cffi) starts requiring a rust compiler. However, using a more recent `pip` should download the correct wheel, prebuilt.