### PR TITLE
Change the URL of the exchange API. Fixes #735

### DIFF
--- a/ihatemoney/currency_convertor.py
+++ b/ihatemoney/currency_convertor.py
@@ -14,7 +14,7 @@ class Singleton(type):
 class CurrencyConverter(object, metaclass=Singleton):
     # Get exchange rates
     no_currency = "XXX"
-    api_url = "https://api.exchangeratesapi.io/latest?base=USD"
+    api_url = "https://api.exchangerate.host/latest?base=USD"
 
     def __init__(self):
         pass


### PR DESCRIPTION
Fixes #735. The API we were using previously seems to now require an API key.