### PR TITLE
Remove obsolete isort flags

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ changedir = {toxinidir}
 [testenv:black]
 commands =
     black --check --target-version=py36 .
-    isort -c -rc .
+    isort -c .
 changedir = {toxinidir}
 
 [testenv:flake8]


### PR DESCRIPTION
See https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#-recursive-or-rc for more info, but this flag isn't required anymore.