### PR TITLE
Using one job for all linting and doc generation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -195,7 +195,7 @@ its source is located inside the `docs folder
 
 Install doc dependencies (within the virtual environment, if any)::
 
-  pip install -r docs/requirements.txt
+  pip install -e .[doc]
 
 And to produce a HTML doc in the `docs/_output` folder::
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-Sphinx==3.5.3
-docutils==0.17.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,10 @@ dev =
     tox>=3.14.6
     zest.releaser>=6.20.1
 
+doc =
+    Sphinx==3.5.3
+    docutils==0.17.1
+
 [options.entry_points]
 console_scripts =
     ihatemoney = ihatemoney.manage:main

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py38,py37,py36,docs,flake8,black
+envlist = py39,py38,py37,py36,lint_docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,20 +14,14 @@ deps =
 # To be sure we are importing ihatemoney pkg from pip-installed version
 changedir = /tmp
 
-[testenv:docs]
-commands = sphinx-build -a -n -b html -d docs/_build/doctrees docs docs/_build/html
-deps =
-    -rdocs/requirements.txt
-changedir = {toxinidir}
-
-[testenv:black]
+[testenv:lint_docs]
 commands =
     black --check --target-version=py36 .
     isort -c .
-changedir = {toxinidir}
-
-[testenv:flake8]
-commands = flake8 ihatemoney
+    flake8 ihatemoney
+    sphinx-build -a -n -b html -d docs/_build/doctrees docs docs/_build/html
+deps =
+    -e.[dev,doc]
 changedir = {toxinidir}
 
 [flake8]
@@ -41,5 +35,5 @@ extend-ignore =
 python =
   3.6: py36
   3.7: py37
-  3.8: py38, docs, black, flake8
+  3.8: py38, lint_docs
   3.9: py39


### PR DESCRIPTION
Requirements for doc are now an extra require in setup.cfg

This enable a single place for dependencies, and faster CI jobs.