### PR TITLE
remove usage of Flask-Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ update: remove-install-stamp install ## Update the dependencies
 .PHONY: serve
 serve: install ## Run the ihatemoney server
 	@echo 'Running ihatemoney on http://localhost:5000'
-	$(PYTHON) -m ihatemoney.manage runserver
+	$(PYTHON) -m ihatemoney.manage run
 
 .PHONY: test
 test: install-dev ## Run the tests

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,7 +61,7 @@ Test it
 
 Once installed, you can start a test server::
 
-  ihatemoney runserver
+  ihatemoney run
 
 And point your browser at `http://localhost:5000 <http://localhost:5000>`_.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     Flask-Mail~=0.9
     Flask-Migrate>=2.5.3,<3  # Not following semantic versioning (e.g. https://github.com/miguelgrinberg/flask-migrate/commit/1af28ba273de6c88544623b8dc02dd539340294b)
     Flask-RESTful~=0.3
-    Flask-Script~=2.0
     Flask-SQLAlchemy~=2.4
     Flask-WTF~=0.14,>=0.14.3  # See b76da172652da94c1f9c4b2fdd965375da8a2c3f
     WTForms~=2.2.1,<2.3  # See #567
@@ -58,8 +57,12 @@ doc =
     docutils==0.17.1
 
 [options.entry_points]
+flask.commands =
+    generate_password_hash = ihatemoney.manage:password_hash
+    generate-config = ihatemoney.manage:generate_config
+
 console_scripts =
-    ihatemoney = ihatemoney.manage:main
+    ihatemoney = ihatemoney.manage:cli
 
 paste.app_factory =
     main = ihatemoney.run:main


### PR DESCRIPTION
Use flask.cli instead with compatibility layer for existing commands,
such as "runserver".

Flask-Script has been unmaintained for many years, and Flask-Migrate just removed support for it. Let's be mainstream!