### PR TITLE
Fix test for generate_hash_password

### DIFF
--- a/ihatemoney/manage.py
+++ b/ihatemoney/manage.py
@@ -34,10 +34,14 @@ def runserver(ctx):
 
 
 @click.command(name="generate_password_hash")
-def password_hash():
+@click.option(
+    "--method",
+    help="""Password method. See https://werkzeug.palletsprojects.com/en/2.0.x/utils/#werkzeug.security.generate_password_hash""",  # NOQA
+)
+def password_hash(method):
     """Get password from user and hash it without printing it in clear text."""
     password = getpass.getpass(prompt="Password: ")
-    print(generate_password_hash(password))
+    print(generate_password_hash(password, method=method))
 
 
 @click.command()

--- a/ihatemoney/manage.py
+++ b/ihatemoney/manage.py
@@ -34,14 +34,10 @@ def runserver(ctx):
 
 
 @click.command(name="generate_password_hash")
-@click.option(
-    "--method",
-    help="""Password method. See https://werkzeug.palletsprojects.com/en/2.0.x/utils/#werkzeug.security.generate_password_hash""",  # NOQA
-)
-def password_hash(method):
+def password_hash():
     """Get password from user and hash it without printing it in clear text."""
     password = getpass.getpass(prompt="Password: ")
-    print(generate_password_hash(password, method=method))
+    print(generate_password_hash(password))
 
 
 @click.command()

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -89,8 +89,8 @@ class CommandTestCase(BaseTestCase):
     def test_generate_password_hash(self):
         runner = self.app.test_cli_runner()
         with patch("getpass.getpass", new=lambda prompt: "secret"):
-            result = runner.invoke(password_hash)
-            self.assertEqual(len(result.output.strip()), 94)
+            result = runner.invoke(password_hash, ["--method", "pbkdf2:sha256:260000"])
+            self.assertEqual(len(result.output.strip()), 102)
 
     def test_demo_project_deletion(self):
         self.create_project("demo")

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -5,13 +5,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from sqlalchemy import orm
+from werkzeug.security import check_password_hash
 
 from ihatemoney import models
 from ihatemoney.currency_convertor import CurrencyConverter
 from ihatemoney.manage import delete_project, generate_config, password_hash
 from ihatemoney.run import load_configuration
 from ihatemoney.tests.common.ihatemoney_testcase import BaseTestCase, IhatemoneyTestCase
-from werkzeug.security import check_password_hash
 
 # Unset configuration file env var if previously set
 os.environ.pop("IHATEMONEY_SETTINGS_FILE_PATH", None)

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -11,6 +11,7 @@ from ihatemoney.currency_convertor import CurrencyConverter
 from ihatemoney.manage import delete_project, generate_config, password_hash
 from ihatemoney.run import load_configuration
 from ihatemoney.tests.common.ihatemoney_testcase import BaseTestCase, IhatemoneyTestCase
+from werkzeug.security import check_password_hash
 
 # Unset configuration file env var if previously set
 os.environ.pop("IHATEMONEY_SETTINGS_FILE_PATH", None)
@@ -89,8 +90,8 @@ class CommandTestCase(BaseTestCase):
     def test_generate_password_hash(self):
         runner = self.app.test_cli_runner()
         with patch("getpass.getpass", new=lambda prompt: "secret"):
-            result = runner.invoke(password_hash, ["--method", "pbkdf2:sha256:260000"])
-            self.assertEqual(len(result.output.strip()), 102)
+            result = runner.invoke(password_hash)
+            self.assertTrue(check_password_hash(result.output.strip(), "secret"))
 
     def test_demo_project_deletion(self):
         self.create_project("demo")


### PR DESCRIPTION
Fix test by using the function that check password instead of just checking the output length. This length can be variable and will change with Werkzeug 2