### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -6,7 +6,7 @@ from flask import request
 from flask_babel import lazy_gettext as _
 from flask_wtf.file import FileAllowed, FileField, FileRequired
 from flask_wtf.form import FlaskForm
-from jinja2 import Markup
+from markupsafe import Markup
 from werkzeug.security import check_password_hash, generate_password_hash
 from wtforms.fields.core import Label, SelectField, SelectMultipleField
 from wtforms.fields.html5 import DateField, DecimalField, URLField

--- a/ihatemoney/run.py
+++ b/ihatemoney/run.py
@@ -7,7 +7,7 @@ from flask import Flask, g, render_template, request, session
 from flask_babel import Babel, format_currency
 from flask_mail import Mail
 from flask_migrate import Migrate, stamp, upgrade
-from jinja2 import contextfilter
+from jinja2 import pass_context
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from ihatemoney import default_settings
@@ -158,7 +158,7 @@ def create_app(
 
     # Undocumented currencyformat filter from flask_babel is forwarding to Babel format_currency
     # We overwrite it to remove the currency sign ¤ when there is no currency
-    @contextfilter
+    @pass_context
     def currency(context, number, currency=None, *args, **kwargs):
         if currency is None:
             currency = context.get("g").project.default_currency

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -494,12 +494,9 @@ class BudgetTestCase(IhatemoneyTestCase):
             resp.data.decode("utf-8"),
         )
         # Change throttling delay
-        import gc
+        from ihatemoney.web import login_throttler
 
-        for obj in gc.get_objects():
-            if isinstance(obj, utils.LoginThrottler):
-                obj._delay = 0.005
-                break
+        login_throttler._delay = 0.005
         # Wait for delay to expire and retry logging in
         sleep(1)
         resp = self.client.post(

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -8,7 +8,7 @@ import unittest
 from flask import session
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from ihatemoney import models, utils
+from ihatemoney import models
 from ihatemoney.tests.common.ihatemoney_testcase import IhatemoneyTestCase
 from ihatemoney.versioning import LoggingMode
 

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -95,7 +95,7 @@ class CommandTestCase(BaseTestCase):
 
     def test_demo_project_deletion(self):
         self.create_project("demo")
-        self.assertEquals(models.Project.query.get("demo").name, "demo")
+        self.assertEqual(models.Project.query.get("demo").name, "demo")
 
         runner = self.app.test_cli_runner()
         runner.invoke(delete_project, "demo")

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -549,7 +549,7 @@ def export_project(file, format):
 
     return send_file(
         file2export,
-        attachment_filename=f"{g.project.id}-{file}.{format}",
+        download_name=f"{g.project.id}-{file}.{format}",
         as_attachment=True,
     )
 


### PR DESCRIPTION
One particular change for the method to find login_throttler. It was triggering a lot of deprecation warnings due to iterating over all known objects from the garbage collector.