### PR TITLE
tests: ensure that /tmp/ihatemoney.db does not get overwritten

### DIFF
--- a/ihatemoney/tests/common/ihatemoney_testcase.py
+++ b/ihatemoney/tests/common/ihatemoney_testcase.py
@@ -10,6 +10,9 @@ from ihatemoney.run import create_app, db
 class BaseTestCase(TestCase):
 
     SECRET_KEY = "TEST SESSION"
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "TESTING_SQLALCHEMY_DATABASE_URI", "sqlite://"
+    )
 
     def create_app(self):
         # Pass the test object as a configuration.
@@ -60,9 +63,6 @@ class BaseTestCase(TestCase):
 
 
 class IhatemoneyTestCase(BaseTestCase):
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
-        "TESTING_SQLALCHEMY_DATABASE_URI", "sqlite://"
-    )
     TESTING = True
     WTF_CSRF_ENABLED = False  # Simplifies the tests.
 

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -23,14 +23,14 @@ class ConfigurationTestCase(BaseTestCase):
     def test_default_configuration(self):
         """Test that default settings are loaded when no other configuration file is specified"""
         self.assertFalse(self.app.config["DEBUG"])
-        self.assertEqual(
-            self.app.config["SQLALCHEMY_DATABASE_URI"], "sqlite:////tmp/ihatemoney.db"
-        )
         self.assertFalse(self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"])
         self.assertEqual(
             self.app.config["MAIL_DEFAULT_SENDER"],
             ("Budget manager", "budget@notmyidea.org"),
         )
+        self.assertTrue(self.app.config["ACTIVATE_DEMO_PROJECT"])
+        self.assertTrue(self.app.config["ALLOW_PUBLIC_PROJECT_CREATION"])
+        self.assertFalse(self.app.config["ACTIVATE_ADMIN_DASHBOARD"])
 
     def test_env_var_configuration_file(self):
         """Test that settings are loaded from a configuration file specified


### PR DESCRIPTION
Most of the tests are using a separate database, but we have a few tests
that are loading default values and are writing to /tmp/ihatemoney.db.

This is annoying because it's also the database used for development:
running the test suite breaks the dev database.

To fix this, always use a separate testing database to avoid interference.