### PR TITLE
Update the Flask-SQLAlchemy version to v2.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     Flask-Mail~=0.9
     Flask-Migrate>=2.5.3,<4  # Not following semantic versioning (e.g. https://github.com/miguelgrinberg/flask-migrate/commit/1af28ba273de6c88544623b8dc02dd539340294b)
     Flask-RESTful~=0.3
-    Flask-SQLAlchemy~=2.4
+    Flask-SQLAlchemy~=2.5
     Flask-WTF~=0.14,>=0.14.3  # See b76da172652da94c1f9c4b2fdd965375da8a2c3f
     WTForms>=2.3.1,<2.4
     Flask>=1.1,<3.0


### PR DESCRIPTION
The upstream SQLAlchemy project made a breaking change in v1.4 and
v2.5 of Flask-SQLAlchemy is now needed.

Fixes #798 