### PR TITLE
"a free software" -> "free software"

### DIFF
--- a/ihatemoney/messages.pot
+++ b/ihatemoney/messages.pot
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -861,4 +861,3 @@ msgstr ""
 
 msgid "Period"
 msgstr ""
-

--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -159,7 +159,7 @@
 
           <div class="footer-left">
             <p>
-              <a href="https://github.com/spiral-project/ihatemoney">{{ _("\"I hate money\" is free software") }}</a><span class="d-none d-sm-inline"></span>,
+              <a href="https://github.com/spiral-project/ihatemoney">{{ _("\"I hate money\" is a free software") }}</a><span class="d-none d-sm-inline"></span>,
               {{ _("you can contribute and improve it!") }}</span>
             </p>
           </div>

--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -159,7 +159,7 @@
 
           <div class="footer-left">
             <p>
-              <a href="https://github.com/spiral-project/ihatemoney">{{ _("\"I hate money\" is a free software") }}</a><span class="d-none d-sm-inline"></span>,
+              <a href="https://github.com/spiral-project/ihatemoney">{{ _("\"I hate money\" is free software") }}</a><span class="d-none d-sm-inline"></span>,
               {{ _("you can contribute and improve it!") }}</span>
             </p>
           </div>

--- a/ihatemoney/translations/bn_BD/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/bn_BD/LC_MESSAGES/messages.po
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -950,4 +950,3 @@ msgstr ""
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/cs/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/cs/LC_MESSAGES/messages.po
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -968,4 +968,3 @@ msgstr ""
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/de/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/de/LC_MESSAGES/messages.po
@@ -790,7 +790,7 @@ msgstr "Dokumentation"
 msgid "Administation Dashboard"
 msgstr "Dashboard Administration"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" ist freie Software"
 
 msgid "you can contribute and improve it!"
@@ -1020,4 +1020,3 @@ msgstr "Zeitraum"
 
 #~ msgid "removed"
 #~ msgstr "entfernt"
-

--- a/ihatemoney/translations/el/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/el/LC_MESSAGES/messages.po
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -973,4 +973,3 @@ msgstr "Περίοδος"
 
 #~ msgid "removed"
 #~ msgstr "αφαιρέθηκε"
-

--- a/ihatemoney/translations/eo/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/eo/LC_MESSAGES/messages.po
@@ -784,7 +784,7 @@ msgstr "Dokumentaro"
 msgid "Administation Dashboard"
 msgstr "Administra panelo"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "«I hate money» estas libera programo"
 
 msgid "you can contribute and improve it!"
@@ -986,4 +986,3 @@ msgstr "Periodo"
 
 #~ msgid "removed"
 #~ msgstr "forigis"
-

--- a/ihatemoney/translations/es/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/es/LC_MESSAGES/messages.po
@@ -751,7 +751,7 @@ msgstr "Documentación"
 msgid "Administation Dashboard"
 msgstr "Panel de administración"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -956,4 +956,3 @@ msgstr "Período"
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/es_419/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/es_419/LC_MESSAGES/messages.po
@@ -791,7 +791,7 @@ msgstr "Documentación"
 msgid "Administation Dashboard"
 msgstr "Panel de administración"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" es un software libre"
 
 msgid "you can contribute and improve it!"
@@ -1020,4 +1020,3 @@ msgstr "Período"
 
 #~ msgid "removed"
 #~ msgstr "removido"
-

--- a/ihatemoney/translations/fr/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/fr/LC_MESSAGES/messages.po
@@ -794,7 +794,7 @@ msgstr "Documentation"
 msgid "Administation Dashboard"
 msgstr "Panneau d'aministration"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "« I hate money » est un logiciel libre"
 
 msgid "you can contribute and improve it!"
@@ -1050,7 +1050,7 @@ msgstr "Période"
 #~ msgid "Project settings"
 #~ msgstr "Options du projet"
 
-#~ msgid "This is a free software"
+#~ msgid "This is free software"
 #~ msgstr "Ceci est un logiciel libre"
 
 #~ msgid "Invite people to join this project!"

--- a/ihatemoney/translations/hi/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/hi/LC_MESSAGES/messages.po
@@ -791,7 +791,7 @@ msgstr "प्रलेखन"
 msgid "Administation Dashboard"
 msgstr "व्यवस्थापन डैशबोर्ड"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" एक मुफ्त सॉफ्टवेयर है"
 
 msgid "you can contribute and improve it!"
@@ -995,4 +995,3 @@ msgstr "अवधि"
 
 #~ msgid "removed"
 #~ msgstr "हटाया गया"
-

--- a/ihatemoney/translations/id/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/id/LC_MESSAGES/messages.po
@@ -784,7 +784,7 @@ msgstr "Dokumentasi"
 msgid "Administation Dashboard"
 msgstr "Dasbor Administrasi"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" adalah perangkat lunak gratis"
 
 msgid "you can contribute and improve it!"
@@ -1019,4 +1019,3 @@ msgstr "Periode"
 
 #~ msgid "removed"
 #~ msgstr "dihapus"
-

--- a/ihatemoney/translations/it/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/it/LC_MESSAGES/messages.po
@@ -797,7 +797,7 @@ msgstr "Documentazione"
 msgid "Administation Dashboard"
 msgstr "Cruscotto Amministrazione"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" è un software libero"
 
 msgid "you can contribute and improve it!"
@@ -1023,4 +1023,3 @@ msgstr "Periodo"
 
 #~ msgid "removed"
 #~ msgstr "rimosso"
-

--- a/ihatemoney/translations/ja/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/ja/LC_MESSAGES/messages.po
@@ -761,7 +761,7 @@ msgstr "書類"
 msgid "Administation Dashboard"
 msgstr "管理ダッシュボード"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\"は無料のソフトウェアです"
 
 msgid "you can contribute and improve it!"
@@ -959,4 +959,3 @@ msgstr "期間"
 
 #~ msgid "removed"
 #~ msgstr "取り除かれた"
-

--- a/ihatemoney/translations/ms/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/ms/LC_MESSAGES/messages.po
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"

--- a/ihatemoney/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/nb_NO/LC_MESSAGES/messages.po
@@ -821,7 +821,7 @@ msgid "Administation Dashboard"
 msgstr "Administrasjonsoversiktspanel"
 
 #, fuzzy
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"Jeg hater penger\" er fri programvare"
 
 msgid "you can contribute and improve it!"
@@ -1045,7 +1045,7 @@ msgstr "Periode"
 #~ msgid "Project settings"
 #~ msgstr "Prosjektinnstillinger"
 
-#~ msgid "This is a free software"
+#~ msgid "This is free software"
 #~ msgstr "Dette er fri programvare"
 
 #~ msgid "Invite people to join this project!"

--- a/ihatemoney/translations/nl/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/nl/LC_MESSAGES/messages.po
@@ -780,7 +780,7 @@ msgstr "Documentatie"
 msgid "Administation Dashboard"
 msgstr "Administratie-overzicht"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" is vrije software"
 
 msgid "you can contribute and improve it!"
@@ -1010,4 +1010,3 @@ msgstr "Periode"
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/pl/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/pl/LC_MESSAGES/messages.po
@@ -789,7 +789,7 @@ msgstr "Dokumentacja"
 msgid "Administation Dashboard"
 msgstr "Kokpit administracyjny"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "„I Hate Money” to darmowe oprogramowanie"
 
 msgid "you can contribute and improve it!"
@@ -1015,4 +1015,3 @@ msgstr "Okres"
 
 #~ msgid "removed"
 #~ msgstr "usunięty"
-

--- a/ihatemoney/translations/pt/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/pt/LC_MESSAGES/messages.po
@@ -790,7 +790,7 @@ msgstr "Documentação"
 msgid "Administation Dashboard"
 msgstr "Painel de Administração"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" é um software livre"
 
 msgid "you can contribute and improve it!"
@@ -996,4 +996,3 @@ msgstr "Período"
 
 #~ msgid "removed"
 #~ msgstr "removido"
-

--- a/ihatemoney/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/pt_BR/LC_MESSAGES/messages.po
@@ -788,7 +788,7 @@ msgstr "Documentação"
 msgid "Administation Dashboard"
 msgstr "Painel de Administração"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" é um software livre"
 
 msgid "you can contribute and improve it!"
@@ -994,4 +994,3 @@ msgstr "Período"
 
 #~ msgid "removed"
 #~ msgstr "removido"
-

--- a/ihatemoney/translations/ru/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/ru/LC_MESSAGES/messages.po
@@ -790,7 +790,7 @@ msgstr "Документация"
 msgid "Administation Dashboard"
 msgstr "Панель инструментов администратора"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\" I hate money \" - бесплатная программа"
 
 msgid "you can contribute and improve it!"
@@ -1012,4 +1012,3 @@ msgstr "Период"
 
 #~ msgid "removed"
 #~ msgstr "удалено"
-

--- a/ihatemoney/translations/sr/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/sr/LC_MESSAGES/messages.po
@@ -742,7 +742,7 @@ msgstr "Dokumentacija"
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -947,4 +947,3 @@ msgstr "Period"
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/sv/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/sv/LC_MESSAGES/messages.po
@@ -760,7 +760,7 @@ msgstr "Dokumentation"
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"Jag hatar pengar\" är en fri mjukvara"
 
 msgid "you can contribute and improve it!"
@@ -956,4 +956,3 @@ msgstr "Period"
 
 #~ msgid "removed"
 #~ msgstr "togs bort"
-

--- a/ihatemoney/translations/ta/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/ta/LC_MESSAGES/messages.po
@@ -764,7 +764,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -969,4 +969,3 @@ msgstr ""
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/tr/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/tr/LC_MESSAGES/messages.po
@@ -788,7 +788,7 @@ msgstr "Belgelendirme"
 msgid "Administation Dashboard"
 msgstr "Yönetici Gösterge Paneli"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "\"I hate money\" özgür bir yazılımdır"
 
 msgid "you can contribute and improve it!"
@@ -1014,4 +1014,3 @@ msgstr "Dönem"
 
 #~ msgid "removed"
 #~ msgstr "kaldırıldı"
-

--- a/ihatemoney/translations/uk/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/uk/LC_MESSAGES/messages.po
@@ -749,7 +749,7 @@ msgstr ""
 msgid "Administation Dashboard"
 msgstr ""
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr ""
 
 msgid "you can contribute and improve it!"
@@ -970,4 +970,3 @@ msgstr ""
 
 #~ msgid "changed in a unknown way"
 #~ msgstr ""
-

--- a/ihatemoney/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/ihatemoney/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -763,7 +763,7 @@ msgstr "文件"
 msgid "Administation Dashboard"
 msgstr "管理面板"
 
-msgid "\"I hate money\" is a free software"
+msgid "\"I hate money\" is free software"
 msgstr "“I hate money\"是一个免费软件"
 
 msgid "you can contribute and improve it!"
@@ -977,4 +977,3 @@ msgstr "期间"
 
 #~ msgid "removed"
 #~ msgstr "移除"
-


### PR DESCRIPTION
In English, "software" is an [uncountable noun](https://dictionary.cambridge.org/grammar/british-grammar/uncountable-nouns). You could say "a free piece of software" or "some free software", but in this context it feels most natural to just drop the article entirely.