### PR TITLE
Display monthly statistics for the range of months where the project was active

### DIFF
--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+import datetime
 
 from dateutil.parser import parse
 from debts import settle
@@ -608,8 +608,8 @@ class Bill(db.Model):
     owers = db.relationship(Person, secondary=billowers)
 
     amount = db.Column(db.Float)
-    date = db.Column(db.Date, default=datetime.now)
-    creation_date = db.Column(db.Date, default=datetime.now)
+    date = db.Column(db.Date, default=datetime.datetime.now)
+    creation_date = db.Column(db.Date, default=datetime.datetime.now)
     what = db.Column(db.UnicodeText)
     external_link = db.Column(db.UnicodeText)
 
@@ -623,7 +623,7 @@ class Bill(db.Model):
     def __init__(
         self,
         amount: float,
-        date: datetime = None,
+        date: datetime.datetime = None,
         external_link: str = "",
         original_currency: str = "",
         owers: list = [],

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -8,12 +8,10 @@ Basically, this blueprint takes care of the authentication and provides
 some shortcuts to make your life better when coding (see `pull_project`
 and `add_project_id` for a quick overview)
 """
-from datetime import datetime
 from functools import wraps
 import json
 import os
 
-from dateutil.relativedelta import relativedelta
 from flask import (
     Blueprint,
     abort,
@@ -852,12 +850,13 @@ def strip_ip_addresses():
 @main.route("/<project_id>/statistics")
 def statistics():
     """Compute what each participant has paid and spent and display it"""
-    today = datetime.now()
+    # Determine range of months between which there are bills
+    months = g.project.active_months_range()
     return render_template(
         "statistics.html",
         members_stats=g.project.members_stats,
         monthly_stats=g.project.monthly_stats,
-        months=[today - relativedelta(months=i) for i in range(12)],
+        months=months,
         current_view="statistics",
     )
 


### PR DESCRIPTION
Currently, we display a hard-coded "one year" range of monthly statistics
starting from today.  This generally is not the intended behaviour: for
instance, on an archived project, the bills might all be older than one
year, so the table only displays months without any operation.

Instead, display all months between the first and last bills.  There might
be empty months in the middle, but that's intended, because we want all
months to be consecutive.

If there are no bills, simply display an empty table.