### PR TITLE
Consistently use questions in bill form

### DIFF
--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -308,7 +308,7 @@ class BillForm(FlaskForm):
     date = DateField(_("When?"), validators=[DataRequired()], default=datetime.now)
     what = StringField(_("What?"), validators=[DataRequired()])
     payer = SelectField(_("Who paid?"), validators=[DataRequired()], coerce=int)
-    amount = CalculatorStringField(_("How much ?"), validators=[DataRequired()])
+    amount = CalculatorStringField(_("How much?"), validators=[DataRequired()])
     currency_helper = CurrencyConverter()
     original_currency = SelectField(_("Currency"), validators=[DataRequired()])
     external_link = URLField(

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -305,10 +305,10 @@ class ResetPasswordForm(FlaskForm):
 
 
 class BillForm(FlaskForm):
-    date = DateField(_("Date"), validators=[DataRequired()], default=datetime.now)
+    date = DateField(_("When?"), validators=[DataRequired()], default=datetime.now)
     what = StringField(_("What?"), validators=[DataRequired()])
-    payer = SelectField(_("Payer"), validators=[DataRequired()], coerce=int)
-    amount = CalculatorStringField(_("Amount paid"), validators=[DataRequired()])
+    payer = SelectField(_("Who paid?"), validators=[DataRequired()], coerce=int)
+    amount = CalculatorStringField(_("How much ?"), validators=[DataRequired()])
     currency_helper = CurrencyConverter()
     original_currency = SelectField(_("Currency"), validators=[DataRequired()])
     external_link = URLField(


### PR DESCRIPTION
I suggest to be consistent with the question-style of our bill form.

Extra-bonus, this will be consistent with the expense table column names.

Isn't that beautiful ?