### PR TITLE
Allow using PostgreSQL with docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ENV DEBUG="False" \
     LEGAL_LINK="False"
 
 RUN mkdir -p /etc/ihatemoney &&\
-    pip install --no-cache-dir gunicorn pymysql;
+    apk update && apk add postgresql-dev gcc python3-dev musl-dev &&\
+    pip install --no-cache-dir gunicorn pymysql psycopg2;
 
 ADD . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ENV DEBUG="False" \
 
 RUN mkdir -p /etc/ihatemoney &&\
     apk update && apk add postgresql-dev gcc python3-dev musl-dev &&\
-    pip install --no-cache-dir gunicorn pymysql psycopg2;
+    pip install --no-cache-dir gunicorn pymysql psycopg2 &&\
+    apk del gcc python3-dev musl-dev; # Keep postgresql-dev installed, sine it is needed at runtime
 
 ADD . /src
 


### PR DESCRIPTION
Install `psycopg2`, which is needed to access a PostgreSQL database.

Resolves #924 