### PR TITLE
Allow clicking buttons behind messages div

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -470,6 +470,11 @@ tr.payer_line .balance-name {
   position: absolute;
   top: 4.5rem;
   width: 100%;
+  pointer-events: none;
+}
+
+.messages .alert {
+  pointer-events: auto;
 }
 
 .light {


### PR DESCRIPTION
If an alert is shown, any elements at the same height cannot be clicked, which is pretty frustrating, because it hides the "New Bill" button. This happens because the "messages" div is positioned absolutely with a width of 100%. 

This PR solves this issue by disabling pointer-events for that div and enabling them again specifically for alerts in that div.