### PR TITLE
Do not require a captcha when using the API

### DIFF
--- a/ihatemoney/api/common.py
+++ b/ihatemoney/api/common.py
@@ -50,7 +50,7 @@ def need_auth(f):
 
 class ProjectsHandler(Resource):
     def post(self):
-        form = ProjectForm(meta={"csrf": False})
+        form = ProjectForm(meta={"csrf": False}, bypass_captcha=True)
         if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             project = form.save()
             db.session.add(project)
@@ -71,7 +71,7 @@ class ProjectHandler(Resource):
         return "DELETED"
 
     def put(self, project):
-        form = EditProjectForm(id=project.id, meta={"csrf": False})
+        form = EditProjectForm(id=project.id, meta={"csrf": False}, bypass_captcha=True)
         if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             form.update(project)
             db.session.commit()

--- a/ihatemoney/api/common.py
+++ b/ihatemoney/api/common.py
@@ -50,7 +50,7 @@ def need_auth(f):
 
 class ProjectsHandler(Resource):
     def post(self):
-        form = ProjectForm(meta={"csrf": False}, bypass_captcha=True)
+        form = ProjectForm(meta={"csrf": False})
         if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             project = form.save()
             db.session.add(project)
@@ -71,7 +71,7 @@ class ProjectHandler(Resource):
         return "DELETED"
 
     def put(self, project):
-        form = EditProjectForm(id=project.id, meta={"csrf": False}, bypass_captcha=True)
+        form = EditProjectForm(id=project.id, meta={"csrf": False})
         if form.validate() and current_app.config.get("ALLOW_PUBLIC_PROJECT_CREATION"):
             form.update(project)
             db.session.commit()

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -198,7 +198,7 @@ class ProjectForm(EditProjectForm):
     submit = SubmitField(_("Create the project"))
 
     def __init__(self, *args, **kwargs):
-        self.bypass_captcha = kwargs.get('bypass_captcha', False)
+        self.bypass_captcha = kwargs.get("bypass_captcha", False)
         super().__init__(*args, **kwargs)
 
     def save(self):

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -197,10 +197,6 @@ class ProjectForm(EditProjectForm):
     password = PasswordField(_("Private code"), validators=[DataRequired()])
     submit = SubmitField(_("Create the project"))
 
-    def __init__(self, *args, **kwargs):
-        self.bypass_captcha = kwargs.get("bypass_captcha", False)
-        super().__init__(*args, **kwargs)
-
     def save(self):
         """Create a new project with the information given by this form.
 
@@ -232,15 +228,14 @@ class ProjectForm(EditProjectForm):
             )
             raise ValidationError(Markup(message))
 
-    @classmethod
-    def enable_captcha(cls):
-        captchaField = StringField(
-            _("Which is a real currency: Euro or Petro dollar?"),
-        )
-        setattr(cls, "captcha", captchaField)
+
+class ProjectFormWithCaptcha(ProjectForm):
+    captcha = StringField(
+        _("Which is a real currency: Euro or Petro dollar?"),
+    )
 
     def validate_captcha(form, field):
-        if not field.data.lower() == _("euro") and not form.bypass_captcha:
+        if not field.data.lower() == _("euro"):
             message = _("Please, validate the captcha to proceed.")
             raise ValidationError(Markup(message))
 

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -197,6 +197,10 @@ class ProjectForm(EditProjectForm):
     password = PasswordField(_("Private code"), validators=[DataRequired()])
     submit = SubmitField(_("Create the project"))
 
+    def __init__(self, *args, **kwargs):
+        self.bypass_captcha = kwargs.get('bypass_captcha', False)
+        super().__init__(*args, **kwargs)
+
     def save(self):
         """Create a new project with the information given by this form.
 
@@ -232,12 +236,11 @@ class ProjectForm(EditProjectForm):
     def enable_captcha(cls):
         captchaField = StringField(
             _("Which is a real currency: Euro or Petro dollar?"),
-            validators=[DataRequired()],
         )
         setattr(cls, "captcha", captchaField)
 
     def validate_captcha(form, field):
-        if not field.data.lower() == _("euro"):
+        if not field.data.lower() == _("euro") and not form.bypass_captcha:
             message = _("Please, validate the captcha to proceed.")
             raise ValidationError(Markup(message))
 

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -286,6 +286,7 @@ class CaptchaTestCase(IhatemoneyTestCase):
             assert len(models.Project.query.all()) == 1
 
     def test_api_project_creation_does_not_need_captcha(self):
+        self.client.get('/')
         resp = self.client.post(
             "/api/projects",
             data={

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -286,7 +286,7 @@ class CaptchaTestCase(IhatemoneyTestCase):
             assert len(models.Project.query.all()) == 1
 
     def test_api_project_creation_does_not_need_captcha(self):
-        self.client.get('/')
+        self.client.get("/")
         resp = self.client.post(
             "/api/projects",
             data={

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -47,6 +47,7 @@ from ihatemoney.forms import (
     MemberForm,
     PasswordReminder,
     ProjectForm,
+    ProjectFormWithCaptcha,
     ResetPasswordForm,
     UploadForm,
     get_billform_for,
@@ -263,8 +264,7 @@ def authenticate(project_id=None):
 
 def get_project_form():
     if current_app.config.get("ENABLE_CAPTCHA", False):
-        ProjectForm.enable_captcha()
-
+        return ProjectFormWithCaptcha()
     return ProjectForm()
 
 


### PR DESCRIPTION
This was trickier than expected, due to some side effects : when the
captcha is set to `True` via configuration, it doesn't change the
behavior directly of the ProjectForm class, but does so only when the
project form is used in the `web.py` module.

So, when just using the API (and not using the web.py module, for
instance during tests — manual or functional), no problem was shown,
and everything was working properly.

But at soon as somebody sees the "/" endpoint, the captcha was
required, by both the API and the `web.py` module.

This fixes it by adding a way to bypass the captcha with a new
`bypass_captcha` property on the form.