### PR TITLE
[Performance] Get weight sum along with bills to scale

### DIFF
--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -256,6 +256,12 @@ class Project(db.Model):
         )
 
     def get_bill_weights(self):
+        """
+        Return all bills for this project, along with the sum of weight for each bill.
+        Each line is a (float, Bill) tuple.
+
+        Result is unordered.
+        """
         return (
             db.session.query(func.sum(Person.weight), Bill)
             .options(orm.subqueryload(Bill.owers))
@@ -267,6 +273,7 @@ class Project(db.Model):
         )
 
     def get_bill_weights_ordered(self):
+        """Ordered version of get_bill_weights"""
         return self.ordered_bills(self.get_bill_weights())
 
     def get_member_bills(self, member_id):

--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -246,9 +246,10 @@ class Project(db.Model):
 
     def get_bills(self):
         """Return the list of bills related to this project"""
-        return self.ordered_bills(self.get_bills_unordered())
+        return self.order_bills(self.get_bills_unordered())
 
-    def ordered_bills(self, query):
+    @staticmethod
+    def order_bills(query):
         return (
             query.order_by(Bill.date.desc())
             .order_by(Bill.creation_date.desc())
@@ -274,7 +275,7 @@ class Project(db.Model):
 
     def get_bill_weights_ordered(self):
         """Ordered version of get_bill_weights"""
-        return self.ordered_bills(self.get_bill_weights())
+        return self.order_bills(self.get_bill_weights())
 
     def get_member_bills(self, member_id):
         """Return the list of bills related to a specific member"""

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -1,7 +1,7 @@
 {% extends "sidebar_table_layout.html" %}
 
-{%- macro bill_amount(bill, currency=bill.original_currency, amount=bill.amount) %}
-    {{ amount|currency(currency) }} ({{ _("%(amount)s each", amount=bill.pay_each_default(amount)|currency(currency)) }})
+{%- macro bill_amount_weighted(bill, weights, currency=bill.original_currency, amount=bill.amount) %}
+    {{ amount|currency(currency) }} ({{ _("%(amount)s each", amount=(amount / weights)|currency(currency)) }})
 {% endmacro -%}
 
 {% block title %} - {{ g.project.name }}{% endblock %}
@@ -109,7 +109,7 @@
                 </th><th>{{ _("Actions") }}</th></tr>
             </thead>
         <tbody>
-        {% for bill in bills.items %}
+        {% for (weights, bill) in bills.items %}
         <tr owers="{{bill.owers|join(',','id')}}" payer="{{bill.payer.id}}">
                 <td>
                     <span data-toggle="tooltip" data-placement="top"
@@ -128,8 +128,8 @@
                 {%- endif %}</td>
                 <td>
                     <span data-toggle="tooltip" data-placement="top"
-                        title="{{ bill_amount(bill, g.project.default_currency, bill.converted_amount) if bill.original_currency != g.project.default_currency else '' }}">
-                        {{ bill_amount(bill) }}
+                        title="{{ bill_amount_weighted(bill, weights, g.project.default_currency, bill.converted_amount) if bill.original_currency != g.project.default_currency else '' }}">
+                        {{ bill_amount_weighted(bill, weights) }}
                     </span>
                 </td>
                 <td class="bill-actions">

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -1,6 +1,6 @@
 {% extends "sidebar_table_layout.html" %}
 
-{%- macro bill_amount_weighted(bill, weights, currency=bill.original_currency, amount=bill.amount) %}
+{%- macro weighted_bill_amount(bill, weights, currency=bill.original_currency, amount=bill.amount) %}
     {{ amount|currency(currency) }} ({{ _("%(amount)s each", amount=(amount / weights)|currency(currency)) }})
 {% endmacro -%}
 
@@ -128,8 +128,8 @@
                 {%- endif %}</td>
                 <td>
                     <span data-toggle="tooltip" data-placement="top"
-                        title="{{ bill_amount_weighted(bill, weights, g.project.default_currency, bill.converted_amount) if bill.original_currency != g.project.default_currency else '' }}">
-                        {{ bill_amount_weighted(bill, weights) }}
+                        title="{{ weighted_bill_amount(bill, weights, g.project.default_currency, bill.converted_amount) if bill.original_currency != g.project.default_currency else '' }}">
+                        {{ weighted_bill_amount(bill, weights) }}
                     </span>
                 </td>
                 <td class="bill-actions">

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -164,7 +164,6 @@ class ModelsTestCase(IhatemoneyTestCase):
                 pay_each_expected = 10 / 3
                 self.assertEqual(bill.amount / weight, pay_each_expected)
 
-
     def test_bill_pay_each(self):
 
         self.post_project("raclette")

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -108,6 +108,63 @@ class CommandTestCase(BaseTestCase):
 
 
 class ModelsTestCase(IhatemoneyTestCase):
+    def test_weighted_bills(self):
+        """Test the SQL request that fetch all bills and weights"""
+        self.post_project("raclette")
+
+        # add members
+        self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
+        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "tata"})
+        # Add a member with a balance=0 :
+        self.client.post("/raclette/members/add", data={"name": "pépé"})
+
+        # create bills
+        self.client.post(
+            "/raclette/add",
+            data={
+                "date": "2011-08-10",
+                "what": "fromage à raclette",
+                "payer": 1,
+                "payed_for": [1, 2, 3],
+                "amount": "10.0",
+            },
+        )
+
+        self.client.post(
+            "/raclette/add",
+            data={
+                "date": "2011-08-10",
+                "what": "red wine",
+                "payer": 2,
+                "payed_for": [1],
+                "amount": "20",
+            },
+        )
+
+        self.client.post(
+            "/raclette/add",
+            data={
+                "date": "2011-08-10",
+                "what": "delicatessen",
+                "payer": 1,
+                "payed_for": [1, 2],
+                "amount": "10",
+            },
+        )
+        project = models.Project.query.get_by_name(name="raclette")
+        for (weight, bill) in project.get_bill_weights().all():
+            if bill.what == "red wine":
+                pay_each_expected = 20 / 2
+                self.assertEqual(bill.amount / weight, pay_each_expected)
+            if bill.what == "fromage à raclette":
+                pay_each_expected = 10 / 4
+                self.assertEqual(bill.amount / weight, pay_each_expected)
+            if bill.what == "delicatessen":
+                pay_each_expected = 10 / 3
+                self.assertEqual(bill.amount / weight, pay_each_expected)
+
+
     def test_bill_pay_each(self):
 
         self.post_project("raclette")

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -654,9 +654,7 @@ def list_bills():
     # set the last selected payer as default choice if exists
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
-    bills = g.project.get_bill_weights_ordered().paginate(
-        per_page=500, error_out=True
-    )
+    bills = g.project.get_bill_weights_ordered().paginate(per_page=500, error_out=True)
 
     return render_template(
         "list_bills.html",

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -654,14 +654,16 @@ def list_bills():
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
 
-    # Each item will be (weight_sum, Bill) tuple
-    weights_bills = g.project.get_bill_weights_ordered().paginate(
+    # Each item will be (weight_sum, Bill) tuple.
+    # TODO: improve this awkward result using column_property:
+    # https://docs.sqlalchemy.org/en/14/orm/mapped_sql_expr.html.
+    weighted_bills = g.project.get_bill_weights_ordered().paginate(
         per_page=100, error_out=True
     )
 
     return render_template(
         "list_bills.html",
-        bills=weights_bills,
+        bills=weighted_bills,
         member_form=MemberForm(g.project),
         bill_form=bill_form,
         csrf_form=csrf_form,

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -653,7 +653,7 @@ def list_bills():
     # set the last selected payer as default choice if exists
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
-    bills = g.project.get_bill_weights_ordered().paginate(per_page=500, error_out=True)
+    bills = g.project.get_bill_weights_ordered().paginate(per_page=100, error_out=True)
 
     return render_template(
         "list_bills.html",

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -654,11 +654,8 @@ def list_bills():
     # set the last selected payer as default choice if exists
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
-    # Preload the "owers" relationship for all bills
-    bills = (
-        g.project.get_bills()
-        .options(orm.subqueryload(Bill.owers))
-        .paginate(per_page=100, error_out=True)
+    bills = g.project.get_bill_weights_ordered().paginate(
+        per_page=500, error_out=True
     )
 
     return render_template(

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -653,11 +653,13 @@ def list_bills():
     # set the last selected payer as default choice if exists
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
-    bills = g.project.get_bill_weights_ordered().paginate(per_page=100, error_out=True)
+
+    # Each item will be (weight_sum, Bill) tuple
+    weights_bills = g.project.get_bill_weights_ordered().paginate(per_page=100, error_out=True)
 
     return render_template(
         "list_bills.html",
-        bills=bills,
+        bills=weights_bills,
         member_form=MemberForm(g.project),
         bill_form=bill_form,
         csrf_form=csrf_form,

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -655,7 +655,9 @@ def list_bills():
         bill_form.payer.data = session["last_selected_payer"]
 
     # Each item will be (weight_sum, Bill) tuple
-    weights_bills = g.project.get_bill_weights_ordered().paginate(per_page=100, error_out=True)
+    weights_bills = g.project.get_bill_weights_ordered().paginate(
+        per_page=100, error_out=True
+    )
 
     return render_template(
         "list_bills.html",

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -654,7 +654,7 @@ def list_bills():
     if "last_selected_payer" in session:
         bill_form.payer.data = session["last_selected_payer"]
 
-    # Each item will be (weight_sum, Bill) tuple.
+    # Each item will be a (weight_sum, Bill) tuple.
     # TODO: improve this awkward result using column_property:
     # https://docs.sqlalchemy.org/en/14/orm/mapped_sql_expr.html.
     weighted_bills = g.project.get_bill_weights_ordered().paginate(

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -31,7 +31,6 @@ from flask import (
 )
 from flask_babel import gettext as _
 from flask_mail import Message
-from sqlalchemy import orm
 from sqlalchemy_continuum import Operation
 from werkzeug.exceptions import NotFound
 from werkzeug.security import check_password_hash, generate_password_hash


### PR DESCRIPTION
Otherwise, we need to get the weight sum for each displayed bill.
Here, we are much more scalable.

With a pagination of 500, we previously had 507 queries if bill currencies were project's default, and nearly the double if not.
Now, we are down to 7.
On my Ryzen 4750G, Flask-debug toolbar profiler told me that displaying 500 out of 1000 bills drop from 2200ms to less than 1000ms.

More performance are expected in other PR.

Finally fixes #159 by continuing #161 