### PR TITLE
Legal link fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV DEBUG="False" \
     SQLALCHEMY_DATABASE_URI="sqlite:////database/ihatemoney.db" \
     SQLALCHEMY_TRACK_MODIFICATIONS="False" \
     ENABLE_CAPTCHA="False" \
-    LEGAL_LINK="False"
+    LEGAL_LINK=""
 
 ADD . /src
 

--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -231,7 +231,7 @@ footer p.footer-links a {
 footer .footer-right {
   float: right;
   margin-top: 6px;
-  max-width: 180px;
+  max-width: 225px;
 }
 
 footer .footer-right a {


### PR DESCRIPTION
Two minor fixes :
- 68a4aa05e8f63ab1501a32ae3b39ad212c7d5c13 set `LEGAL_LINK` default value to "False", icon was displayed and redirected to /False if not overwritten
- displaying legal link in footer caused an overflow

Before :
![image](https://user-images.githubusercontent.com/14979860/143723907-2a9722a0-bc43-4775-8534-b8e67b47cdc1.png)
After :
![image](https://user-images.githubusercontent.com/14979860/143723927-0a9fda4f-0ae0-4c88-ae31-2b941fd03aed.png)
