### PR TITLE
Constrain dependency for Babel >= 2.9.1 to address CVE-2021-42771

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     debts>=0.5,<1
     email_validator>=1.0,<2
     Flask-Babel>=1.0,<3
+    Babel>=2.9.1,<3  # CVE-2021-42771
     Flask-Cors>=3.0.8,<4
     Flask-Mail>=0.9.1,<1
     Flask-Migrate>=2.5.3,<4  # Not following semantic versioning (e.g. https://github.com/miguelgrinberg/flask-migrate/commit/1af28ba273de6c88544623b8dc02dd539340294b)


### PR DESCRIPTION
This makes sure that people upgrading their installation using `pip install -U ihatemoney` will get the fixed version of Babel. By default, `pip` doesn't upgrade dependencies if the currently installed version fulfills dependency constraints.