### PR TITLE
Add functionality to new project creation

### DIFF
--- a/ihatemoney/templates/forms.html
+++ b/ihatemoney/templates/forms.html
@@ -69,12 +69,19 @@
 
     {% include "display_errors.html" %}
     {{ form.hidden_tag() }}
+    <!-- Only display private code if not home page -->
     {% if not home %}
-    {{ input(form.id) }}
+    {{ input(form.id, placeholder="Unique ID used to login") }}
     {% endif %}
-    {{ input(form.name) }}
-    {{ input(form.password) }}
-    {{ input(form.contact_email) }}
+    <!-- Fields that are always shown -->
+    {{ input(form.name, placeholder="Example: Trip to Paris") }}
+    {{ input(form.password, placeholder="Password to access project") }}
+    {{ input(form.contact_email, placeholder="Your email") }}
+    <!-- Only display member name and default currency if not home page -->
+    {% if not home %}
+    {{ input(form.member_name, placeholder="(optional) Add your first project member!") }}
+    {{ input(form.default_currency) }}
+    {% endif %}
     {% if config['ENABLE_CAPTCHA'] %}
     {{ input(form.captcha) }}
     {% endif %}


### PR DESCRIPTION
Closes #525

Changed the new project creation on both the home page and create page (/create route). By changing both pages, we could have one creation flow kept simple and the other creation flow more versatile and customizable. 

Changes:

- Added placeholders to all fields for a better explanation
- For the creation page, added a few more fields for further customization (inspired by [https://splittypie.com/new](SplittyPie))

New home page:
![Screen Shot 2021-12-16 at 5 22 47 AM](https://user-images.githubusercontent.com/12735282/146354259-0fd2e4eb-c904-4239-94e0-4a272418a568.png)

New creation page:
![Screen Shot 2021-12-16 at 5 22 54 AM](https://user-images.githubusercontent.com/12735282/146354287-cea08d33-30fb-4f8d-a386-e12c15d6d739.png)

