### PR TITLE
unpin sqlalchemy to 1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     Jinja2>=3,<4
     requests>=2.22,<3
     SQLAlchemy-Continuum>=1.3.9,<2
-    SQLAlchemy>=1.3.0,<1.4  # New 1.4 changes API, see #728
+    SQLAlchemy>=1.3.0,<1.5
     python-dateutil
 
 [options.extras_require]


### PR DESCRIPTION
sqlalchemy-continuum's latest release supports sqlalchemy 1.4

I notably checked that the history feature works.