### PR TITLE
Add a tooltip to advertize the computation trick on bills. (resolve  #985)

### DIFF
--- a/ihatemoney/templates/forms.html
+++ b/ihatemoney/templates/forms.html
@@ -166,7 +166,9 @@
     {{ input(form.date, inline=True) }}
     {{ input(form.what, inline=True) }}
     {{ input(form.payer, inline=True, class="form-control custom-select") }}
-    {{ input(form.amount, inline=True) }}
+    <div data-toggle="tooltip" data-placement="top" title='{{ _("Simple operations are allowed, e.g. (18+36.2)/3") }}'>
+        {{ input(form.amount, inline=True) }}
+    </div>
 
     <div class="form-group row">
         <label class="col-3" for="payed_for">{{ _("For whom?") }}</label>


### PR DESCRIPTION
Added tooltip to "How much?" field of add/edit bill to let users know about the possibility of computations.

screenshot:
![Screenshot from 2022-01-31 00-00-17](https://user-images.githubusercontent.com/42657588/151721735-c83cfed8-a98e-4df7-965c-cfd58df07414.png)
![Screenshot from 2022-01-30 23-59-56](https://user-images.githubusercontent.com/42657588/151721734-4444cd54-6b4d-46b5-9d1f-74249fba52e2.png)


