### PR TITLE
Purge project history on deletion

### DIFF
--- a/ihatemoney/history.py
+++ b/ihatemoney/history.py
@@ -135,3 +135,12 @@ def get_history(project, human_readable_names=True):
                 history.append(common_properties)
 
     return sorted(history, key=history_sort_key, reverse=True)
+
+
+def purge_history(project):
+    """
+    Erase history linked to a project.
+    You must commit the purge after calling this function.
+    """
+    for query in get_history_queries(project):
+        query.delete(synchronize_session="fetch")

--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -438,7 +438,12 @@ class Project(db.Model):
         return person
 
     def remove_project(self):
+        # We can't import at top level without circular dependencies
+        from ihatemoney.history import purge_history
+
         db.session.delete(self)
+        # Purge AFTER delete to be sure to purge the deletion from history
+        purge_history(self)
         db.session.commit()
 
     def generate_token(self, token_type="auth"):

--- a/ihatemoney/tests/history_test.py
+++ b/ihatemoney/tests/history_test.py
@@ -627,6 +627,38 @@ class HistoryTestCase(IhatemoneyTestCase):
                 self.assertNotIn("owers", entry["prop_changed"])
         self.assertEqual(len(history_list), 6)
 
+    def test_delete_history_with_project(self):
+        self.post_project("raclette", password="party")
+
+        # add participants
+        self.client.post("/raclette/members/add", data={"name": "zorglub"})
+
+        # add bill
+        self.client.post(
+            "/raclette/add",
+            data={
+                "date": "2016-12-31",
+                "what": "fromage à raclette",
+                "payer": 1,
+                "payed_for": [1],
+                "amount": "10",
+                "original_currency": "EUR",
+            },
+        )
+
+        # Delete project
+        self.client.post(
+            "/raclette/delete",
+            data={"password": "party"},
+        )
+
+        # Recreate it
+        self.post_project("raclette", password="party")
+
+        # History should be equal to project creation
+        history_list = history.get_history(self.get_project("raclette"))
+        assert len(history_list) == 1
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -49,7 +49,7 @@ from ihatemoney.forms import (
     ResetPasswordForm,
     get_billform_for,
 )
-from ihatemoney.history import get_history, get_history_queries
+from ihatemoney.history import get_history, get_history_queries, purge_history
 from ihatemoney.models import Bill, LoggingMode, Person, Project, db
 from ihatemoney.utils import (
     LoginThrottler,
@@ -808,8 +808,7 @@ def erase_history():
         )
         return redirect(url_for(".history"))
 
-    for query in get_history_queries(g.project):
-        query.delete(synchronize_session="fetch")
+    purge_history(g.project)
 
     db.session.commit()
     flash(_("Deleted project history."))


### PR DESCRIPTION
Fix #948

Note that there is no confirmation. The whole project is deleted right away, without any possibility to undo.

This is a bit of an anti feature from using SQLAlchemy-continuum, but the code can easily be adapted to delete the project history later.