### PR TITLE
Feature Request: Add a confirmation on expense deletion #1077

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -310,6 +310,11 @@ footer .footer-left {
   background: url("../images/delete.png") no-repeat right;
 }
 
+.bill-actions > form > .confirm.btn-danger {
+  outline-color: #c82333;
+  box-shadow: none;
+}
+
 .bill-actions > .edit {
   background: url("../images/edit.png") no-repeat right;
 }

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -39,7 +39,28 @@
 
     $('#bill_table tbody tr').hover(highlight_owers, unhighlight_owers);
 
+
+
+    let link = $('#delete-bill').find('button');
+    let deleteOriginalHTML = link.html();
+    link.click(function() {
+        if (link.hasClass("confirm")){
+            return true;
+        }
+        link.html("{{_("Are you sure?")}}");
+        link.removeClass("action delete");
+        link.addClass("confirm btn-danger");
+        return false;
+    });
+
+    $('#delete-bill').focusout(function() {
+        link.removeClass("confirm btn-danger");
+        link.html(deleteOriginalHTML);
+        link.addClass("action delete");
+    });
+
 {% endblock %}
+
 
 {% block sidebar %}
     <div class="sidebar_content">
@@ -137,7 +158,7 @@
                 </td>
                 <td class="bill-actions">
                     <a class="edit" href="{{ url_for(".edit_bill", bill_id=bill.id) }}" title="{{ _("edit") }}">{{ _('edit') }}</a>
-                    <form action="{{ url_for(".delete_bill", bill_id=bill.id) }}" method="POST">
+                    <form id="delete-bill"action="{{ url_for(".delete_bill", bill_id=bill.id) }}" method="POST">
                         {{ csrf_form.csrf_token }}
                         <button class="action delete" type="submit" title="{{ _("delete") }}"></button>
                     </form>


### PR DESCRIPTION
Completed feature request #1077 to use the double-click confirmation button that is also found in edit_project.html. This will prevent the accidental deletion of expenses (a destructive operation) with no warning.