### PR TITLE
Added in confirmation pop-up upon bill deletion

### DIFF
--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -139,7 +139,7 @@
                     <a class="edit" href="{{ url_for(".edit_bill", bill_id=bill.id) }}" title="{{ _("edit") }}">{{ _('edit') }}</a>
                     <form action="{{ url_for(".delete_bill", bill_id=bill.id) }}" method="POST">
                         {{ csrf_form.csrf_token }}
-                        <button class="action delete" type="submit" title="{{ _("delete") }}"></button>
+                        <button onclick="return confirm('Are you sure you want to delete this bill?')" class="action delete" type="submit" title="{{ _("delete") }}"></button>
                     </form>
                     {% if bill.external_link %}
                     <a class="show" href="{{ bill.external_link }}" ref="noopener" target="_blank" title="{{ _("show") }}">{{ _('show') }} </a>


### PR DESCRIPTION
I noticed there was an issue created for the lack of confirmation upon bill deletion. I added in a confirmation pop-up when the user clicks on the delete button on the bill dashboard.