### PR TITLE
Bugfix #1080: "Deactivated users reappeared"

### DIFF
--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -752,6 +752,22 @@ class Bill(db.Model):
         else:
             return 0
 
+    @property
+    def involves_deactivated_members(self):
+        """Check whether the bill contains deactivated member.
+        Return:
+        True if it contains deactivated member,
+        False if not.
+        """
+        owers_id = [int(m.id) for m in self.owers]
+        bill_members = owers_id + [self.payer_id]
+        deactivated_members_count = (
+            Person.query.filter(Person.id.in_(bill_members))
+            .filter(Person.activated.is_(False))
+            .count()
+        )
+        return deactivated_member_count != 0
+
     def __str__(self):
         return self.what
 

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -148,10 +148,22 @@
                     </span>
                 </td>
                 <td class="bill-actions d-flex align-items-center">
-                    <a class="edit" href="{{ url_for(".edit_bill", bill_id=bill.id) }}" title="{{ _("edit") }}">{{ _('edit') }}</a>
+                    <a class="edit" href="{{ url_for(".edit_bill", bill_id=bill.id) }}" data-toggle="tooltip"
+                        {% if bill.involves_deactivated_members %}
+                            title="Cannot be edited as deactivated members involved"
+                        {% else %}
+                            title="Click to edit this bill"
+                        {% endif %}
+                    >{{ _('edit') }}</a>
                     <form class="delete-bill" action="{{ url_for(".delete_bill", bill_id=bill.id) }}" method="POST">
                         {{ csrf_form.csrf_token }}
-                        <button class="action delete" type="submit" title="{{ _("delete") }}"></button>
+                        <button class="action delete" type="submit" data-toggle="tooltip"
+                            {% if bill.involves_deactivated_members %}
+                                title="Cannot be deleted as deactivated members involved"
+                            {% else %}
+                                title="Click to delete this bill"
+                            {% endif %}
+                        ></button>
                     </form>
                     {% if bill.external_link %}
                     <a class="show" href="{{ bill.external_link }}" ref="noopener" target="_blank" title="{{ _("show") }}">{{ _('show') }} </a>

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -806,6 +806,10 @@ def delete_bill(bill_id):
     if not bill:
         return redirect(url_for(".list_bills"))
 
+    # Check if the bill contains deactivated member. If yes, stop deleting.
+    if bill.involves_deactivated_members:
+        return redirect(url_for(".list_bills"))
+
     db.session.delete(bill)
     db.session.commit()
     flash(_("The bill has been deleted"))
@@ -819,6 +823,10 @@ def edit_bill(bill_id):
     bill = Bill.query.get(g.project, bill_id)
     if not bill:
         raise NotFound()
+
+    # Check if the bill contains deactivated member. If yes, stop editing.
+    if bill.involves_deactivated_members:
+        return redirect(url_for(".list_bills"))
 
     form = get_billform_for(g.project, set_default=False)
 


### PR DESCRIPTION
Fixed #1080 by adding the deactivated member check. Corresponding test functions were also finished.<br>
Details:<br>1. Added the deactivated member check for editing/deleting bills. 
Compare the payer&owers list (POL) of the bill with the active member list (AML). If the relative complement of AML in POL (POL \ AML) is not empty, then the bill contains deactivated members and should not be edited/deleted.<br>2. Added two corresponding integration test functions.<br>
Test:<br>Passed all the tests.

