### PR TITLE
Solved the issue deactivated user's bill cannot be edited

### DIFF
--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -8,6 +8,7 @@ Basically, this blueprint takes care of the authentication and provides
 some shortcuts to make your life better when coding (see `pull_project`
 and `add_project_id` for a quick overview)
 """
+
 import datetime
 from functools import wraps
 import hashlib
@@ -813,6 +814,12 @@ def edit_bill(bill_id):
     bill = Bill.query.get(g.project, bill_id)
     if not bill:
         raise NotFound()
+    payer_id = bill.payer_id
+    payer = Person.query.get(payer_id)
+
+    if not payer.activated:
+        flash(_("The payer is deactivated. You cannot edit the bill."))
+        return redirect(url_for(".list_bills"))
 
     form = get_billform_for(g.project, set_default=False)
 


### PR DESCRIPTION
Solved #1080 that deactivated user's bill can still be edited.
Before, this system allows to deactivate user with non-zero bill value. However, the bill can still be edited by other active member.
After, the deactivated user's bill cannot be edited with a prompt noticing the users.
Test has been made with this fix.