### PR TITLE
Allow bills with an amount of zero

### DIFF
--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -387,9 +387,7 @@ class BillForm(FlaskForm):
         self.payed_for.data = self.payed_for.default
 
     def validate_amount(self, field):
-        if field.data == "0":
-            raise ValidationError(_("Bills can't be null"))
-        elif decimal.Decimal(field.data) > decimal.MAX_EMAX:
+        if decimal.Decimal(field.data) > decimal.MAX_EMAX:
             # See https://github.com/python-babel/babel/issues/821
             raise ValidationError(f"Result is too high: {field.data}")
 

--- a/ihatemoney/tests/api_test.py
+++ b/ihatemoney/tests/api_test.py
@@ -926,7 +926,7 @@ class APITestCase(IhatemoneyTestCase):
             },
             headers=self.get_auth("raclette"),
         )
-        self.assertStatus(400, req)
+        self.assertStatus(201, req)
 
     def test_project_creation_with_mixed_case(self):
         self.api_create("Raclette")

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -1589,7 +1589,7 @@ class BudgetTestCase(IhatemoneyTestCase):
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
 
         # null amount
-        resp = self.client.post(
+        self.client.post(
             "/raclette/add",
             data={
                 "date": "2016-12-31",
@@ -1600,11 +1600,12 @@ class BudgetTestCase(IhatemoneyTestCase):
                 "original_currency": "EUR",
             },
         )
-        self.assertIn('<p class="alert alert-danger">', resp.data.decode("utf-8"))
 
-        resp = self.client.get("/raclette/")
-        # No bills, the previous one was not added
-        self.assertIn("No bills", resp.data.decode("utf-8"))
+        # Bill should have been accepted
+        project = self.get_project("raclette")
+        self.assertEqual(project.get_bills().count(), 1)
+        last_bill = project.get_bills().first()
+        self.assertEqual(last_bill.amount, 0)
 
     def test_decimals_on_weighted_members_list(self):
         self.post_project("raclette")


### PR DESCRIPTION
Bills with an amount of zero may be useful to remember that a transaction happened on a specific date, while the amount doesn't matter.

I use that with per-year projects when a reimbursement happens in year N but is relative to year N-1: I record it with an amount of zero in the project of year N, and with the real amount in the project of year N-1.

Besides, it's already possible to create such bills: while "0" is refused, "0.0" is accepted.  There are no visible issues with this kind of bills.