### PR TITLE
[CI] Build mutli-architecture docker image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -61,6 +61,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platform: linux/amd64,linux/arm64,linux/arm/v7
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I built an arm/v7 image locally with buildx and run it on my raspberry pi 3 successfully (https://hub.docker.com/r/greedybro/ihatemoney/tags)

Since the project CI is already using buildx via `docker/build-push-action@v2`, it should only require to had a list of architectures to build for.

The list should cover most of user needs with `armv7` for rapsberry 3 and before, and `arm64` for Mac with Apple silicon and raspberry 4 (and probabilly future models)

Closes  #1066