### PR TITLE
Drop python 3.7

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -36,25 +36,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         dependencies: [normal]
         database: [sqlite]
-        # Test other databases only with one version of Python (Debian buster has 3.7)
+        # Test other databases only with one version of Python
         include:
-          - python-version: 3.7
+          - python-version: 3.8
             dependencies: normal
             database: postgresql
-          - python-version: 3.7
+          - python-version: 3.8
             dependencies: normal
             database: mariadb
           # Try a few variants with the minimal versions supported
-          - python-version: 3.7
+          - python-version: 3.8
             dependencies: minimal
             database: sqlite
-          - python-version: 3.7
+          - python-version: 3.8
             dependencies: minimal
             database: postgresql
-          - python-version: 3.7
+          - python-version: 3.8
             dependencies: minimal
             database: mariadb
           - python-version: 3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "3.7"
   - "3.8"
   - "3.9"
 script: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This document describes changes between each past release.
 
 ## 6.0.2 (unreleased)
 
+### Breaking changes
+- Drop Python 3.7 support
 
-- Nothing changed yet.
+The minimum supported version is now Python 3.8, and the project is
+tested with up to Python 3.11
 
 
 ## 6.0.1 (2023-07-22)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ highly encouraged to do so.
 
 ## Requirements
 
--   **Python**: version 3.7 to 3.11.
+-   **Python**: version 3.8 to 3.11.
 -   **Backends**: SQLite, PostgreSQL, MariaDB (version 10.3.2 or above),
     Memory.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ Some Paas (Platform-as-a-Service), provide a documentation or even a quick insta
 
 «Ihatemoney» depends on:
 
--   **Python**: any version from 3.7 to 3.11 will work.
+-   **Python**: any version from 3.8 to 3.11 will work.
 -   **A database backend**: choose among SQLite, PostgreSQL, MariaDB (>=
     10.3.2).
 -   **Virtual environment** (recommended): [python3-venv]{.title-ref}

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -35,14 +35,14 @@ special instructions:
 #### Switch to a supported version of Python
 
 ::: {note}
-If you are already using Python ≥ 3.7, you can skip this section, no
+If you are already using Python ≥ 3.8, you can skip this section, no
 special action is required.
 :::
 
-If you were running IHateMoney using Python < 3.7, you must, **before**
+If you were running IHateMoney using Python < 3.8, you must, **before**
 upgrading:
 
-1.  Ensure to have a Python ≥ 3.7 available on your system
+1.  Ensure to have a Python ≥ 3.8 available on your system
 
 2.  Rebuild your virtual environment (if any). It will *not* alter your
     database nor configuration. For example, if your virtual environment

--- a/ihatemoney/api/common.py
+++ b/ihatemoney/api/common.py
@@ -107,7 +107,7 @@ class APIMemberForm(MemberForm):
 
     def save(self, project, person):
         person.activated = self.activated.data
-        return super(APIMemberForm, self).save(project, person)
+        return super().save(project, person)
 
 
 class MembersHandler(Resource):

--- a/ihatemoney/currency_convertor.py
+++ b/ihatemoney/currency_convertor.py
@@ -10,11 +10,11 @@ class Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 
-class CurrencyConverter(object, metaclass=Singleton):
+class CurrencyConverter(metaclass=Singleton):
     # Get exchange rates
     no_currency = "XXX"
     api_url = "https://api.exchangerate.host/latest?base=USD"

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -92,7 +92,7 @@ class CommaDecimalField(DecimalField):
     def process_formdata(self, value):
         if value:
             value[0] = str(value[0]).replace(",", ".")
-        return super(CommaDecimalField, self).process_formdata(value)
+        return super().process_formdata(value)
 
 
 class CalculatorStringField(StringField):
@@ -116,7 +116,7 @@ class CalculatorStringField(StringField):
 
             valuelist[0] = str(eval_arithmetic_expression(value))
 
-        return super(CalculatorStringField, self).process_formdata(valuelist)
+        return super().process_formdata(valuelist)
 
 
 class EditProjectForm(FlaskForm):
@@ -400,7 +400,7 @@ class MemberForm(FlaskForm):
     submit = SubmitField(_("Add"))
 
     def __init__(self, project, edit=False, *args, **kwargs):
-        super(MemberForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.project = project
         self.edit = edit
 

--- a/ihatemoney/migrations/env.py
+++ b/ihatemoney/migrations/env.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig

--- a/ihatemoney/models.py
+++ b/ihatemoney/models.py
@@ -229,7 +229,7 @@ class Project(db.Model):
         # but this is called very rarely so we can tolerate if it's a bit
         # slow. And doing this in Python is much more readable, see #784.
         nb_currencies = len(
-            set(bill.original_currency for bill in self.get_bills_unordered())
+            {bill.original_currency for bill in self.get_bills_unordered()}
         )
         return nb_currencies > 1
 

--- a/ihatemoney/monkeypath_continuum.py
+++ b/ihatemoney/monkeypath_continuum.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import six
 import sqlalchemy as sa
 from sqlalchemy_continuum import __version__ as continuum_version
 from sqlalchemy_continuum.exc import ImproperlyConfigured
@@ -53,7 +52,7 @@ class PatchedTransactionFactory(TransactionFactory):
                 except AttributeError:  # SQLAlchemy < 1.4
                     registry = Base._decl_class_registry
 
-                if isinstance(user_cls, six.string_types):
+                if isinstance(user_cls, str):
                     try:
                         user_cls = registry[user_cls]
                     except KeyError:
@@ -82,8 +81,7 @@ class PatchedTransactionFactory(TransactionFactory):
                 )
                 return "<Transaction %s>" % ", ".join(
                     (
-                        "%s=%r" % (field, value)
-                        if not isinstance(value, six.integer_types)
+                        f"{field}={value!r}" if not isinstance(value, int)
                         # We want the following line to ensure that longs get
                         # shown without the ugly L suffix on python 2.x
                         # versions

--- a/ihatemoney/tests/api_test.py
+++ b/ihatemoney/tests/api_test.py
@@ -42,7 +42,7 @@ class APITestCase(IhatemoneyTestCase):
     def get_auth(self, username, password=None):
         password = password or username
         base64string = (
-            base64.encodebytes(f"{username}:{password}".encode("utf-8"))
+            base64.encodebytes(f"{username}:{password}".encode())
             .decode("utf-8")
             .replace("\n", "")
         )
@@ -518,11 +518,11 @@ class APITestCase(IhatemoneyTestCase):
 
             # should return the id
             self.assertStatus(201, req)
-            self.assertEqual(req.data.decode("utf-8"), "{}\n".format(id))
+            self.assertEqual(req.data.decode("utf-8"), f"{id}\n")
 
             # get this bill's details
             req = self.client.get(
-                "/api/projects/raclette/bills/{}".format(id),
+                f"/api/projects/raclette/bills/{id}",
                 headers=self.get_auth("raclette"),
             )
 

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -708,7 +708,7 @@ class BudgetTestCase(IhatemoneyTestCase):
         )
 
         balance = self.get_project("raclette").balance
-        self.assertEqual(set(balance.values()), set([19.0, -19.0]))
+        self.assertEqual(set(balance.values()), {19.0, -19.0})
 
         # Bill with negative amount
         self.client.post(
@@ -802,7 +802,7 @@ class BudgetTestCase(IhatemoneyTestCase):
         )
 
         balance = self.get_project("raclette").balance
-        self.assertEqual(set(balance.values()), set([6, -6]))
+        self.assertEqual(set(balance.values()), {6, -6})
 
     def test_trimmed_members(self):
         self.post_project("raclette")
@@ -1044,11 +1044,9 @@ class BudgetTestCase(IhatemoneyTestCase):
         # same as in the main table.
         order = ["fred", "pépé", "tata", "zorglub"]
         regex1 = r".*".join(
-            r"<td class=\"balance-name\">{}</td>".format(name) for name in order
+            rf"<td class=\"balance-name\">{name}</td>" for name in order
         )
-        regex2 = r".*".join(
-            r"<td class=\"d-md-none\">{}</td>".format(name) for name in order
-        )
+        regex2 = r".*".join(rf"<td class=\"d-md-none\">{name}</td>" for name in order)
         # Build the regexp ourselves to be able to pass the DOTALL flag
         # (so that ".*" matches newlines)
         self.assertRegex(response.data.decode("utf-8"), re.compile(regex1, re.DOTALL))

--- a/ihatemoney/tests/import_test.py
+++ b/ihatemoney/tests/import_test.py
@@ -6,7 +6,7 @@ from ihatemoney.tests.common.ihatemoney_testcase import IhatemoneyTestCase
 from ihatemoney.utils import list_of_dicts2csv, list_of_dicts2json
 
 
-class CommonTestCase(object):
+class CommonTestCase:
     class Import(IhatemoneyTestCase):
         def setUp(self):
             super().setUp()

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -8,7 +8,6 @@ import operator
 import os
 import re
 import smtplib
-import socket
 
 from babel import Locale
 from babel.numbers import get_currency_name, get_currency_symbol
@@ -50,7 +49,7 @@ def send_email(mail_message):
     # to check for both.
     try:
         current_app.mail.send(mail_message)
-    except (smtplib.SMTPException, socket.error):
+    except (smtplib.SMTPException, OSError):
         return False
     # Email was sent successfully
     return True
@@ -100,7 +99,7 @@ class Redirect303(HTTPException, RoutingException):
         return redirect(self.new_url, 303)
 
 
-class PrefixedWSGI(object):
+class PrefixedWSGI:
 
     """
     Wrap the application in this middleware and configure the
@@ -148,7 +147,7 @@ def minimal_round(*args, **kw):
 
 def static_include(filename):
     fullpath = os.path.join(current_app.static_folder, filename)
-    with open(fullpath, "r") as f:
+    with open(fullpath) as f:
         return f.read()
 
 
@@ -284,7 +283,7 @@ def eval_arithmetic_expression(expr):
     try:
         result = _eval(ast.parse(expr, mode="eval").body)
     except (SyntaxError, TypeError, ZeroDivisionError, KeyError):
-        raise ValueError("Error evaluating expression: {}".format(expr))
+        raise ValueError(f"Error evaluating expression: {expr}")
 
     return result
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ license = Custom BSD Beerware
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,py310,py39,py38,py37,lint_docs
+envlist = py311,py310,py39,py38,lint_docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -17,10 +17,10 @@ changedir = /tmp
 
 [testenv:lint_docs]
 commands =
-    black --check --target-version=py37 .
+    black --check --target-version=py38 .
     isort --check --profile black .
     flake8 ihatemoney
-    vermin --no-tips --violations -t=3.7- .
+    vermin --no-tips --violations -t=3.8- .
     sphinx-build -a -n -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     -e.[dev,doc]
@@ -35,6 +35,5 @@ extend-ignore =
 
 [travis]
 python =
-  3.7: py37
   3.8: py38, lint_docs
   3.9: py39


### PR DESCRIPTION
[Python 3.7 reached end of life on 27 Jun 2023](https://devguide.python.org/versions/). This PR removes tests for python 3.7, updates the documentation to reflect the new minimum python version. I also applied [pyupgrade](https://github.com/asottile/pyupgrade) to automatically update the codebase to a more recent syntax: `find ihatemoney conf ihatemoney -name "*.py" -exec pyupgrade --py38-plus "{}" +`.