### PR TITLE
Fix 404 page crash

### DIFF
--- a/ihatemoney/templates/layout.html
+++ b/ihatemoney/templates/layout.html
@@ -119,12 +119,14 @@
             {% if session['is_admin'] %}
             <li><a class="dropdown-item" href="{{ url_for("main.dashboard") }}">{{ _("Dashboard") }}</a></li>
             {% endif %}
+            {% if g.logout_form %}
             <li>
               <form action="{{ url_for("main.exit") }}" method="post">
                 {{ g.logout_form.hidden_tag() }}
                 {{ g.logout_form.submit(class="dropdown-item") }}
               </form>
             </li>
+            {% endif %}
           </ul>
         </li>
       {% endif %}


### PR DESCRIPTION
The 404 page crashes when the user is logged in:

      File "/home/zorun/code/ihatemoney/ihatemoney/templates/404.html", line 1, in top-level template code
        {% extends "layout.html" %}
      File "/home/zorun/code/ihatemoney/ihatemoney/templates/layout.html", line 124, in top-level template code
        {{ g.logout_form.hidden_tag() }}
      File "/home/zorun/venv/py3-ihatemoney/lib/python3.9/site-packages/jinja2/environment.py", line 474, in getattr
        return getattr(obj, attribute)
    jinja2.exceptions.UndefinedError: 'flask.ctx._AppCtxGlobals object' has no attribute 'logout_form'

This is because the logout form is defined by a URL processor, and this does not seem to apply for all pages.

To solve this, simply skip the logout form if it's not defined.