### PR TITLE
Require private code to edit a project settings, document better the invite options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,9 +34,9 @@ the token (of course, you need to authenticate):
     $ curl --basic -u demo:demo https://ihatemoney.org/api/projects/demo/token
     {"token": "WyJ0ZXN0Il0.Rt04fNMmxp9YslCRq8hB6jE9s1Q"}
 
-Make sure to store this token securely: it allows full access to the
+Make sure to store this token securely: it allows almost full access to the
 project. For instance, use it to obtain information about the project
-(replace PROJECT_TOKEN with the actual token):
+(replace `PROJECT_TOKEN` with the actual token):
 
     $ curl --oauth2-bearer "PROJECT_TOKEN" https://ihatemoney.org/api/projects/demo
 
@@ -51,7 +51,8 @@ simply create an URL of the form:
 
     https://ihatemoney.org/demo/join/PROJECT_TOKEN
 
-Such a link grants full access to the project associated with the token.
+Such a link grants read-write access to the project associated with the token,
+but it does not allow to change project settings.
 
 ### Projects
 
@@ -67,8 +68,8 @@ A project needs the following arguments:
 -   `name`: the project name (string)
 -   `id`: the project identifier (string without special chars or
     spaces)
--   `password`: the project password / secret code (string)
--   `contact_email`: the contact email (string)
+-   `password`: the project password / private code (string)
+-   `contact_email`: the contact email, used to recover the private code (string)
 
 Optional arguments:
 
@@ -83,7 +84,9 @@ Here is the command:
     -d 'name=yay&id=yay&password=yay&contact_email=yay@notmyidea.org'
     "yay"
 
-As you can see, the API returns the identifier of the project.
+As you can see, the API returns the identifier of the project. It might be different
+from what you requested, because the ID is normalized (remove special characters,
+change to lowercase, etc).
 
 #### Getting information about the project
 
@@ -108,7 +111,12 @@ Updating a project is done with the `PUT` verb:
 
     $ curl --basic -u yay:yay -X PUT\
     https://ihatemoney.org/api/projects/yay -d\
-    'name=yay&id=yay&password=yay&contact_email=youpi@notmyidea.org'
+    'name=yay&id=yay&current_password=yay&password=newyay&contact_email=youpi@notmyidea.org'
+
+You need to give the current private code as the `current_password` field. This is a security
+measure to ensure that knowledge of an auth token is not enough to update settings.
+
+Note that in any case you can never change the ID of a project.
 
 #### Deleting a project
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,20 +26,25 @@ A project has four main parameters when it comes to security:
 Somebody with the **private code** can:
 
 -   access the project through the web interface or the API
+-   add, modify or remove participants
 -   add, modify or remove bills
+-   view statistics of the project
 -   view project history
 -   change basic settings of the project
 -   change the email address associated to the project
 -   change the private code of the project
+-   delete the project
 
-Somebody with the **auth token** can manipulate the project through the API to do
-essentially the same thing:
+Somebody with the **auth token** can manipulate the project through the API:
 
 -   access the project
+-   add, modify or remove participants
 -   add, modify or remove bills
--   change basic settings of the project
--   change the email address associated to the project
--   change the private code of the project
+-   view statistics of the project
+-   delete the project
+
+The auth token is not enough to change basic settings of the project,
+or to change the email address or the private code.
 
 The auth token can also be used to build "invitation links". These links
 allow to login on the web interface without knowing the private code,
@@ -61,9 +66,12 @@ The second method is interesting because it does not reveal the private
 code. In particular, somebody that is logged-in through the invitation
 link will not be able to change the private code, because the web
 interface requires a confirmation of the existing private code to change
-it. However, a motivated person could extract the auth token from the
+it. Similarly, changing other important settings or deleting the project
+from the web interface requires knowledge of the private code.
+
+However, a motivated person could extract the auth token from the
 invitation link, use it to access the project through the API, and
-change the private code through the API.
+delete the project through the API.  This is a [known issue](https://github.com/spiral-project/ihatemoney/issues/1206).
 
 ## Removing access to a project
 
@@ -103,6 +111,6 @@ Note, however, that the history feature is primarily meant to protect
 against mistakes: a malicious member can easily remove all entries from
 the history!
 
-The best defense against this kind of issues is\... backups! All data
+The best defense against this kind of issues is... backups! All data
 for a project can be exported through the settings page or through the
-API.
+API. The server administrator can also backup the database.

--- a/ihatemoney/templates/forms.html
+++ b/ihatemoney/templates/forms.html
@@ -100,6 +100,7 @@
     </div>
 
     {{ input(form.default_currency) }}
+    {{ input(form.current_password) }}
     <div class="actions">
         <button class="btn btn-primary">{{ _("Save changes") }}</button>
     </div>

--- a/ihatemoney/templates/send_invites.html
+++ b/ihatemoney/templates/send_invites.html
@@ -7,20 +7,10 @@
     <tbody>
         <tr>
             <td>
-                <h3>{{ _('Share Identifier & code') }}</h3>
+                <h3>{{ _('Share an invitation link') }}</h3>
             </td>
             <td>
-                {{ _("You can share the project identifier and the private code by any communication means.") }}
-                <br />
-                <strong>{{ _('Identifier:') }}</strong> <a href="{{ url_for("main.list_bills", project_id=g.project.id) }}">{{ g.project.id }}</a>
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <h3>{{ _('Share the Link') }}</h3>
-            </td>
-            <td>
-                {{ _("You can directly share the following link via your prefered medium") }}</br>
+                {{ _("The easiest way to invite people is to give them the following invitation link.<br />They will be able to access the project, manage participants, add/edit/delete bills. However, they will not have access to important settings such as changing the private code or deleting the whole project.") }}</br>
                 <a href="{{ url_for(".join_project", _external=True, project_id=g.project.id, token=g.project.generate_token()) }}">
                     {{ url_for(".join_project", _external=True, project_id=g.project.id, token=g.project.generate_token()) }}
                 </a>
@@ -41,11 +31,24 @@
             </td>
             <td>
                 <p>{{ _("Specify a (comma separated) list of email adresses you want to notify about the
-                creation of this budget management project and we will send them an email for you.") }}</p>
+                creation of this budget management project and we will send them an email with the invitation link.") }}</p>
                 {% include "display_errors.html" %}
                 <form class="invites form-horizontal" method="post" accept-charset="utf-8">
                     {{ forms.invites(form) }}
                 </form>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <h3>{{ _('Share Identifier & code') }}</h3>
+            </td>
+            <td>
+                <p>{{ _("You can share the project identifier and the private code by any communication means.<br />Anyone with the private code will have access to the full project, including changing settings such as the private code or project email address, or even deleting the whole project.") }}</p>
+                <p>
+                    <strong>{{ _('Identifier:') }}</strong> <a href="{{ url_for("main.list_bills", project_id=g.project.id) }}">{{ g.project.id }}</a>
+                    <br />
+                    <strong>{{ _('Private code:') }}</strong> {{ _('the private code was defined when you created the project') }}
+                </p>
             </td>
         </tr>
     </tbody>

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -167,7 +167,7 @@ class BudgetTestCase(IhatemoneyTestCase):
         self.login("raclette")
         self.post_project("raclette")
         response = self.client.get("/raclette/invite").data.decode("utf-8")
-        link = extract_link(response, "share the following link")
+        link = extract_link(response, "give them the following invitation link")
 
         self.client.post("/exit")
         response = self.client.get(link)

--- a/ihatemoney/tests/history_test.py
+++ b/ihatemoney/tests/history_test.py
@@ -19,11 +19,12 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("<td> -- </td>"), 1)
         self.assertNotIn("127.0.0.1", resp.data.decode("utf-8"))
 
-    def change_privacy_to(self, logging_preference):
+    def change_privacy_to(self, current_password, logging_preference):
         # Change only logging_preferences
         new_data = {
             "name": "demo",
             "contact_email": "demo@notmyidea.org",
+            "current_password": current_password,
             "password": "demo",
             "default_currency": "XXX",
         }
@@ -76,6 +77,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         new_data = {
             "name": "demo2",
             "contact_email": "demo2@notmyidea.org",
+            "current_password": "demo",
             "password": "123456",
             "project_history": "y",
             "default_currency": "USD",  # Currency changed from default
@@ -114,7 +116,7 @@ class HistoryTestCase(IhatemoneyTestCase):
             resp.data.decode("utf-8"),
         )
 
-        self.change_privacy_to(LoggingMode.DISABLED)
+        self.change_privacy_to("demo", LoggingMode.DISABLED)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -122,7 +124,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("<td> -- </td>"), 2)
         self.assertNotIn("127.0.0.1", resp.data.decode("utf-8"))
 
-        self.change_privacy_to(LoggingMode.RECORD_IP)
+        self.change_privacy_to("demo", LoggingMode.RECORD_IP)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -132,7 +134,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("<td> -- </td>"), 2)
         self.assertEqual(resp.data.decode("utf-8").count("127.0.0.1"), 1)
 
-        self.change_privacy_to(LoggingMode.ENABLED)
+        self.change_privacy_to("demo", LoggingMode.ENABLED)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -141,7 +143,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("127.0.0.1"), 2)
 
     def test_project_privacy_edit2(self):
-        self.change_privacy_to(LoggingMode.RECORD_IP)
+        self.change_privacy_to("demo", LoggingMode.RECORD_IP)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -149,7 +151,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("<td> -- </td>"), 1)
         self.assertEqual(resp.data.decode("utf-8").count("127.0.0.1"), 1)
 
-        self.change_privacy_to(LoggingMode.DISABLED)
+        self.change_privacy_to("demo", LoggingMode.DISABLED)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -159,7 +161,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         self.assertEqual(resp.data.decode("utf-8").count("<td> -- </td>"), 1)
         self.assertEqual(resp.data.decode("utf-8").count("127.0.0.1"), 2)
 
-        self.change_privacy_to(LoggingMode.ENABLED)
+        self.change_privacy_to("demo", LoggingMode.ENABLED)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)
@@ -171,6 +173,7 @@ class HistoryTestCase(IhatemoneyTestCase):
         new_data = {
             "name": "demo2",
             "contact_email": "demo2@notmyidea.org",
+            "current_password": "demo",
             "password": "123456",
             "default_currency": "USD",
         }
@@ -233,7 +236,7 @@ class HistoryTestCase(IhatemoneyTestCase):
 
     def test_disable_clear_no_new_records(self):
         # Disable logging
-        self.change_privacy_to(LoggingMode.DISABLED)
+        self.change_privacy_to("demo", LoggingMode.DISABLED)
 
         # Ensure we can't clear history with a GET or with a password-less POST
         resp = self.client.get("/demo/erase_history")
@@ -276,13 +279,13 @@ class HistoryTestCase(IhatemoneyTestCase):
 
     def test_clear_ip_records(self):
         # Enable IP Recording
-        self.change_privacy_to(LoggingMode.RECORD_IP)
+        self.change_privacy_to("demo", LoggingMode.RECORD_IP)
 
         # Do lots of database operations to generate IP address entries
         self.do_misc_database_operations(LoggingMode.RECORD_IP)
 
         # Disable IP Recording
-        self.change_privacy_to(LoggingMode.ENABLED)
+        self.change_privacy_to("123456", LoggingMode.ENABLED)
 
         resp = self.client.get("/demo/history")
         self.assertEqual(resp.status_code, 200)

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -429,7 +429,8 @@ def edit_project():
         db.session.add(project)
         db.session.commit()
 
-        return redirect(url_for("main.list_bills"))
+        flash(_("Project settings have been changed successfully."))
+        return redirect(url_for("main.edit_project"))
     else:
         edit_form.name.data = g.project.name
 


### PR DESCRIPTION
This is something we had documented in our [security documentation](https://ihatemoney.readthedocs.io/en/latest/security.html#giving-access-to-a-project), but we didn't actually do it...

As mentioned in this document, this has good security properties: you can invite somebody with an invitation link, and they will be able to access the project but not change the private code (because they don't know the current private code).

This new check also applies to all other settings (email address, history settings, currency), which is desirable.  Only somebody with knowledge of the private code can now change these settings.

Finally, document these security properties in the invitation page.