### PR TITLE
docs: dynamic year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,12 @@
+import datetime
+
 templates_path = ["_templates"]
 source_suffix = ".rst"
 master_doc = "index"
 
 project = "I hate money"
-copyright = "2011-2021, The 'I hate money' team"
+year = datetime.datetime.now().strftime("%Y")
+copyright = f"2011-{year}, The 'I hate money' team"
 
 version = "5.0"
 release = "5.0"


### PR DESCRIPTION
The year of the documentation was 2021, with this PR it will take the current year of the documentation generation.