### PR TITLE
Simplifies adding a bill with keyboard only

### DIFF
--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -11,6 +11,11 @@
 {% block js %}
     {% if add_bill %} $('#new-bill > a').click(); {% endif %}
 
+    // focus on first field when adding a bill
+    $("#bill-form").on('shown.bs.modal', function(){
+            $(this).find('#what').focus();
+    });
+
     // ask for confirmation before removing an user
     $('.action.delete').each(function(){
         var link = $(this).find('button');
@@ -101,7 +106,7 @@
 </ul>
 {% endif %}
 <span id="new-bill" class="ml-auto pb-2" {% if not g.project.members %} data-toggle="tooltip" title="{{_('You should start by adding participants')}}" {% endif %}>
-    <a href="{{ url_for('.add_bill') }}" class="btn btn-primary {% if not g.project.members %} disabled {% endif %}" data-toggle="modal" data-keyboard="false" data-target="#bill-form">
+    <a href="{{ url_for('.add_bill') }}" class="btn btn-primary {% if not g.project.members %} disabled {% endif %}" data-toggle="modal" data-keyboard="true" data-target="#bill-form" autofocus>
         <i class="icon icon-white before-text">{{ static_include("images/plus.svg") | safe }}</i>
         {{ _("Add a new bill") }}
     </a>


### PR DESCRIPTION
This PR proposes three small changes to simplify adding a bill with only keyboard:

1. Makes the default focus on the "Add a new bill" button:
![Capture d’écran de 2023-08-28 23-23-50](https://github.com/spiral-project/ihatemoney/assets/12517717/5a71a042-5c27-45b1-9dfe-423d0d35f49a)

2. In the "Add a new bill" modal, makes the default focus on the first field:
![Capture d’écran de 2023-08-28 23-26-03](https://github.com/spiral-project/ihatemoney/assets/12517717/2df95eca-73f8-4038-a4f1-5a58306b3800)

3. Allows to escape the "Add a new bill" modal with the "Esc" key. (Was this intentionally deactivated?)