### PR TITLE
Default owers when adding a bill

### DIFF
--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -645,7 +645,7 @@ def list_bills():
     bill_form = get_billform_for(g.project)
     # Used for CSRF validation
     csrf_form = EmptyForm()
-    # set the last selected payer as default choice if exists
+    # set the last selected payer and last selected owers as default choice if they exist
     if "last_selected_payer_per_project" in session:
         if g.project.id in session["last_selected_payer_per_project"]:
             bill_form.payer.data = session["last_selected_payer_per_project"][
@@ -655,6 +655,11 @@ def list_bills():
     else:
         if "last_selected_payer" in session:
             bill_form.payer.data = session["last_selected_payer"]
+    if (
+        "last_selected_payed_for" in session
+        and g.project.id in session["last_selected_payed_for"]
+    ):
+        bill_form.payed_for.data = session["last_selected_payed_for"][g.project.id]
 
     # Each item will be a (weight_sum, Bill) tuple.
     # TODO: improve this awkward result using column_property:
@@ -758,10 +763,13 @@ def add_bill():
     form = get_billform_for(g.project)
     if request.method == "POST":
         if form.validate():
-            # save last selected payer in session
+            # save last selected payer and last selected owers in session
             if "last_selected_payer_per_project" not in session:
                 session["last_selected_payer_per_project"] = {}
             session["last_selected_payer_per_project"][g.project.id] = form.payer.data
+            if "last_selected_payed_for" not in session:
+                session["last_selected_payed_for"] = {}
+            session["last_selected_payed_for"][g.project.id] = form.payed_for.data
             session.update()
 
             db.session.add(form.export(g.project))


### PR DESCRIPTION
# English

In short. Would you find nice to:
1. either remember the owers when adding several bills
2. or allow to define default owers in the settings of a project
?

(This PR implements 1.)


# Français

J'utilise régulièrement IHM dans un projet où je sélectionne toujours les mêmes "Pour qui ?" quand je saisi une facture. C'est un peu long de désélectionner à chaque fois.

Est-ce que vous seriez intéressés par une des propositions suivantes :
1. se rappeler, d'une facture sur l'autre, des derniers "Pour qui ?" sélectionnés (c'est actuellement le cas avec le "Qui a payé ?")
2. ou permettre de définir des "Pour qui ?" par défaut dans les paramètres du projet
?

Ma préférence va à 1 (interface plus légère). Et vous ?

(Cette PR implémente 1.)