### PR TITLE
Add more details for bills in the history

### DIFF
--- a/ihatemoney/history.py
+++ b/ihatemoney/history.py
@@ -83,9 +83,25 @@ def get_history(project, human_readable_names=True):
                 "time": version.transaction.issued_at,
                 "operation_type": version.operation_type,
                 "object_type": object_type,
+                "bill_details": None,
                 "object_desc": object_str,
                 "ip": version.transaction.remote_addr,
             }
+
+            if object_type == "Bill":
+                if version.operation_type == Operation.INSERT or not version.previous:
+                    detailed_version = version
+                else:
+                    detailed_version = version.previous
+                details = {
+                    "date": detailed_version.date,
+                    "payer": describe_version(detailed_version.payer),
+                    "amount": detailed_version.amount,
+                    "owers": [describe_version(o) for o in detailed_version.owers],
+                    "external_link": detailed_version.external_link,
+                    "original_currency": detailed_version.original_currency,
+                }
+                common_properties["bill_details"] = details
 
             if version.operation_type == Operation.UPDATE:
                 # Only iterate the changeset if the previous version

--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -424,6 +424,15 @@ footer .footer-left {
   display: table-cell;
 }
 
+/* used to tuncate long urls */
+.truncated {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 250px;
+    display: inline-block;
+    vertical-align: top;
+}
 
 .balance .balance-value {
   text-align: right;

--- a/ihatemoney/templates/history.html
+++ b/ihatemoney/templates/history.html
@@ -91,6 +91,21 @@
     {% endif %}
 {% endmacro %}
 
+{% macro bill_details(details, before=False) %}
+    {% set owers_list_str=details.owers|localize_list|safe %}
+    <details class="small">
+        <summary>{% if before %} {{ _("Details of the bill (before the change)") }} {% else %} {{ _("Details of the bill") }} {% endif %}</summary>
+        {{ _("Date:") }} {{ details.date|em_surround }}.
+        {{ _("Payer:") }} {{ details.payer|em_surround }}.
+        {{ _("Amount:") }} {{ details.amount|currency(details.original_currency)|em_surround }}.
+        {{ _("Owers:") }} {{ owers_list_str }}.
+        {% if details.external_link %}
+            {{ _("External link:") }}
+            <a class="truncated" href="{{ details.external_link }}">{{ details.external_link }}</a>
+        {% endif %}
+    </details>
+{% endmacro %}
+
 {% block sidebar %}
     <div id="table_overflow">
         {{ balance_table(show_weight=False, show_header=True) }}
@@ -177,6 +192,7 @@
                         {% trans %}Project {{ name }} added{% endtrans %}
                     {% elif event.object_type == "Bill" %}
                         {% trans %}Bill {{ name }} added{% endtrans %}
+                        {{ bill_details(event.bill_details) }}
 
                     {% elif event.object_type == "Person" %}
                         {% trans %}Participant {{ name }} added{% endtrans %}
@@ -220,6 +236,7 @@
                         {% else %}
                             {% trans %}Bill {{ name }} modified{% endtrans %}
                         {% endif %}
+                        {{ bill_details(event.bill_details, before=True) }}
 
                     {% elif event.object_type == "Person" %}
                         {% if event.prop_changed == "activated" %}
@@ -243,6 +260,7 @@
                 {% elif event.operation_type == OperationType.DELETE %}
                     {% if event.object_type == "Bill" %}
                         {% trans %}Bill {{ name }} removed{% endtrans %}
+                        {{ bill_details(event.bill_details) }}
                     {% elif event.object_type == "Person" %}
                         {% trans %}Participant {{ name }} removed{% endtrans %}
                     {% endif %}

--- a/ihatemoney/templates/history.html
+++ b/ihatemoney/templates/history.html
@@ -177,9 +177,11 @@
                         {% trans %}Project {{ name }} added{% endtrans %}
                     {% elif event.object_type == "Bill" %}
                         {% trans %}Bill {{ name }} added{% endtrans %}
+
                     {% elif event.object_type == "Person" %}
                         {% trans %}Participant {{ name }} added{% endtrans %}
                     {% endif %}
+
                 {% elif event.operation_type == OperationType.UPDATE  %}
                     {% if event.object_type == "Project" %}
                         {% if event.prop_changed == "password" %}
@@ -200,7 +202,7 @@
                             {% set new_description=event.val_after|em_surround %}
                             {% trans %}Bill {{ name }} renamed to {{ new_description }}{% endtrans %}
                         {% elif event.prop_changed == "external_link" %}
-                            {{ bill_property_change(event, _("External link"), None, "<a href='{link}' >{link}</a>".format(link=event.val_after | escape) | safe | em_surround) }}
+                            {{ bill_property_change(event, _("External link"), None, "<a class='truncated' href='{link}' >{link}</a>".format(link=event.val_after | escape) | safe | em_surround) }}
                         {% elif event.prop_changed == "owers_added" %}
                             {{ owers_changed(event, True)}}
                         {% elif event.prop_changed == "owers_removed" %}
@@ -218,6 +220,7 @@
                         {% else %}
                             {% trans %}Bill {{ name }} modified{% endtrans %}
                         {% endif %}
+
                     {% elif event.object_type == "Person" %}
                         {% if event.prop_changed == "activated" %}
                             {% if event.val_after == False %}
@@ -236,12 +239,14 @@
                             {% trans %}Participant {{ name }} modified{% endtrans %}
                         {% endif %}
                     {% endif %}
+
                 {% elif event.operation_type == OperationType.DELETE %}
                     {% if event.object_type == "Bill" %}
                         {% trans %}Bill {{ name }} removed{% endtrans %}
                     {% elif event.object_type == "Person" %}
                         {% trans %}Participant {{ name }} removed{% endtrans %}
                     {% endif %}
+
                 {% else %}
                     {# Should be unreachable #}
                     {% if event.object_type == "Project" %}

--- a/ihatemoney/templates/history.html
+++ b/ihatemoney/templates/history.html
@@ -183,7 +183,7 @@
                 {% elif event.operation_type == OperationType.UPDATE  %}
                     {% if event.object_type == "Project" %}
                         {% if event.prop_changed == "password" %}
-                           {{ _("Project private code changed") }}
+                            {{ _("Project private code changed") }}
                         {% elif event.prop_changed == "logging_preference" %}
                             {{ change_to_logging_preference(event) }}
                         {% elif event.prop_changed == "name" %}
@@ -195,42 +195,44 @@
                         {% else %}
                             {{ _("Project settings modified") }}
                         {% endif %}
-                    {% elif event.prop_changed == "activated" %}
-                        {% if event.val_after == False %}
-                            {% trans %}Participant {{ name }} deactivated{% endtrans %}
-                        {% else %}
-                            {% trans %}Participant {{ name }} reactivated{% endtrans %}
-                        {% endif %}
-                    {% elif event.prop_changed == "name" %}
-                            {% set new_name=event.val_after|em_surround %}
-                            {% trans %}Participant {{ name }} renamed to {{ new_name }}{% endtrans %}
-                    {% elif event.prop_changed == "what" %}
+                    {% elif event.object_type == "Bill" %}
+                        {% if event.prop_changed == "what" %}
                             {% set new_description=event.val_after|em_surround %}
                             {% trans %}Bill {{ name }} renamed to {{ new_description }}{% endtrans %}
-                    {% elif event.prop_changed == "weight" %}
-                        {% set old_weight=event.val_before|em_surround %}
-                        {% set new_weight=event.val_after|em_surround %}
-                        {% trans %}Participant {{ name }}: weight changed from {{ old_weight }} to {{ new_weight }}{% endtrans %}
-                    {% elif event.prop_changed == "external_link" %}
-                        {{ bill_property_change(event, _("External link"), None, "<a href='{link}' >{link}</a>".format(link=event.val_after | escape) | safe | em_surround) }}
-                    {% elif event.prop_changed == "owers_added" %}
-                        {{ owers_changed(event, True)}}
-                    {% elif event.prop_changed == "owers_removed" %}
-                        {{ owers_changed(event, False)}}
-                    {% elif event.prop_changed == "payer" %}
-                        {{ bill_property_change(event, _("Payer"))}}
-                    {% elif event.prop_changed == "amount" %}
-                        {{ bill_property_change(event, _("Amount")) }}
-                    {% elif event.prop_changed == "date" %}
-                        {{ bill_property_change(event, _("Date")) }}
-                    {% elif event.prop_changed == "original_currency" %}
-                        {{ bill_property_change(event, _("Currency")) }}
-                    {% elif event.prop_changed == "converted_amount" %}
-                        {{ bill_property_change(event, _("Amount in %(currency)s", currency=g.project.default_currency)) }}
-                    {% else %}
-                        {% if event.object_type == "Bill" %}
+                        {% elif event.prop_changed == "external_link" %}
+                            {{ bill_property_change(event, _("External link"), None, "<a href='{link}' >{link}</a>".format(link=event.val_after | escape) | safe | em_surround) }}
+                        {% elif event.prop_changed == "owers_added" %}
+                            {{ owers_changed(event, True)}}
+                        {% elif event.prop_changed == "owers_removed" %}
+                            {{ owers_changed(event, False)}}
+                        {% elif event.prop_changed == "payer" %}
+                            {{ bill_property_change(event, _("Payer"))}}
+                        {% elif event.prop_changed == "amount" %}
+                            {{ bill_property_change(event, _("Amount")) }}
+                        {% elif event.prop_changed == "date" %}
+                            {{ bill_property_change(event, _("Date")) }}
+                        {% elif event.prop_changed == "original_currency" %}
+                            {{ bill_property_change(event, _("Currency")) }}
+                        {% elif event.prop_changed == "converted_amount" %}
+                            {{ bill_property_change(event, _("Amount in %(currency)s", currency=g.project.default_currency)) }}
+                        {% else %}
                             {% trans %}Bill {{ name }} modified{% endtrans %}
-                        {% elif event.object_type == "Person" %}
+                        {% endif %}
+                    {% elif event.object_type == "Person" %}
+                        {% if event.prop_changed == "activated" %}
+                            {% if event.val_after == False %}
+                                {% trans %}Participant {{ name }} deactivated{% endtrans %}
+                            {% else %}
+                                {% trans %}Participant {{ name }} reactivated{% endtrans %}
+                            {% endif %}
+                        {% elif event.prop_changed == "name" %}
+                            {% set new_name=event.val_after|em_surround %}
+                            {% trans %}Participant {{ name }} renamed to {{ new_name }}{% endtrans %}
+                        {% elif event.prop_changed == "weight" %}
+                            {% set old_weight=event.val_before|em_surround %}
+                            {% set new_weight=event.val_after|em_surround %}
+                            {% trans %}Participant {{ name }}: weight changed from {{ old_weight }} to {{ new_weight }}{% endtrans %}
+                        {% else %}
                             {% trans %}Participant {{ name }} modified{% endtrans %}
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
This PR add more details for bills in the history for each operation: insert, update, delete.

The idea is to be able to easily know what was a bill at some time (which can be difficult when it has been modified several times).

![Capture d’écran de 2023-09-03 10-04-43](https://github.com/spiral-project/ihatemoney/assets/12517717/cf2c7da0-ffc9-4ffe-9ad2-c54fd87140ce)

The PR also shorten long URL with an ellipsis `...` to avoid big overflows.