### PR TITLE
[Fix] Remember the last selected payer for each project

### DIFF
--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -646,11 +646,15 @@ def list_bills():
     # Used for CSRF validation
     csrf_form = EmptyForm()
     # set the last selected payer as default choice if exists
-    if (
-        "last_selected_payer_per_project" in session
-        and g.project.id in session["last_selected_payer_per_project"]
-    ):
-        bill_form.payer.data = session["last_selected_payer_per_project"][g.project.id]
+    if "last_selected_payer_per_project" in session:
+        if g.project.id in session["last_selected_payer_per_project"]:
+            bill_form.payer.data = session["last_selected_payer_per_project"][
+                g.project.id
+            ]
+    # for backward compatibility, should be removed at some point
+    else:
+        if "last_selected_payer" in session:
+            bill_form.payer.data = session["last_selected_payer"]
 
     # Each item will be a (weight_sum, Bill) tuple.
     # TODO: improve this awkward result using column_property:

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -646,8 +646,11 @@ def list_bills():
     # Used for CSRF validation
     csrf_form = EmptyForm()
     # set the last selected payer as default choice if exists
-    if "last_selected_payer" in session:
-        bill_form.payer.data = session["last_selected_payer"]
+    if (
+        "last_selected_payer_per_project" in session
+        and g.project.id in session["last_selected_payer_per_project"]
+    ):
+        bill_form.payer.data = session["last_selected_payer_per_project"][g.project.id]
 
     # Each item will be a (weight_sum, Bill) tuple.
     # TODO: improve this awkward result using column_property:
@@ -752,7 +755,9 @@ def add_bill():
     if request.method == "POST":
         if form.validate():
             # save last selected payer in session
-            session["last_selected_payer"] = form.payer.data
+            if "last_selected_payer_per_project" not in session:
+                session["last_selected_payer_per_project"] = {}
+            session["last_selected_payer_per_project"][g.project.id] = form.payer.data
             session.update()
 
             db.session.add(form.export(g.project))


### PR DESCRIPTION
Previously the last selected payer was lost when switching of project.

The structure of the variable `last_selected_payer` is changed (now it's a dictionary) then it has been renamed to `last_selected_payer_per_project` to avoid session bugs.