### PR TITLE
Swapping Out 'Fred' for 'Jeanne' in Docs/API – Personal Peacekeeping 😊

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ You can get all the members with a `GET` on
     [{"weight": 1, "activated": true, "id": 31, "name": "Arnaud"},
      {"weight": 1, "activated": true, "id": 32, "name": "Alexis"},
      {"weight": 1, "activated": true, "id": 33, "name": "Olivier"},
-     {"weight": 1, "activated": true, "id": 34, "name": "Fred"}]
+     {"weight": 1, "activated": true, "id": 34, "name": "Jeanne"}]
 
 Add a member with a `POST` request on `/api/projects/<id>/members`:
 
@@ -244,7 +244,7 @@ You can get some project stats with a `GET` on
             "balance": 10.5
         },
         {
-            "member": {"activated": true, "id": 2, "name": "fred", "weight": 1.0},
+            "member": {"activated": true, "id": 2, "name": "jeanne", "weight": 1.0},
             "paid": 5,
             "spent": 15.5,
             "balance": -10.5

--- a/ihatemoney/tests/api_test.py
+++ b/ihatemoney/tests/api_test.py
@@ -314,7 +314,7 @@ class TestAPI(IhatemoneyTestCase):
         # edit the participant
         req = self.client.put(
             "/api/projects/raclette/members/1",
-            data={"name": "Fred", "weight": 2},
+            data={"name": "Jeanne", "weight": 2},
             headers=self.get_auth("raclette"),
         )
 
@@ -326,14 +326,14 @@ class TestAPI(IhatemoneyTestCase):
         )
 
         self.assertStatus(200, req)
-        assert "Fred" == json.loads(req.data.decode("utf-8"))["name"]
+        assert "Jeanne" == json.loads(req.data.decode("utf-8"))["name"]
         assert 2 == json.loads(req.data.decode("utf-8"))["weight"]
 
         # edit this member with same information
-        # (test PUT idemopotence)
+        # (test PUT idempotence)
         req = self.client.put(
             "/api/projects/raclette/members/1",
-            data={"name": "Fred"},
+            data={"name": "Jeanne"},
             headers=self.get_auth("raclette"),
         )
 
@@ -342,7 +342,7 @@ class TestAPI(IhatemoneyTestCase):
         # de-activate the participant
         req = self.client.put(
             "/api/projects/raclette/members/1",
-            data={"name": "Fred", "activated": False},
+            data={"name": "Jeanne", "activated": False},
             headers=self.get_auth("raclette"),
         )
         self.assertStatus(200, req)
@@ -356,7 +356,7 @@ class TestAPI(IhatemoneyTestCase):
         # re-activate the participant
         req = self.client.put(
             "/api/projects/raclette/members/1",
-            data={"name": "Fred", "activated": True},
+            data={"name": "Jeanne", "activated": True},
             headers=self.get_auth("raclette"),
         )
 
@@ -388,7 +388,7 @@ class TestAPI(IhatemoneyTestCase):
 
         # add participants
         self.api_add_member("raclette", "zorglub")
-        self.api_add_member("raclette", "fred")
+        self.api_add_member("raclette", "jeanne")
         self.api_add_member("raclette", "quentin")
 
         # get the list of bills (should be empty)
@@ -429,7 +429,7 @@ class TestAPI(IhatemoneyTestCase):
             "payer_id": 1,
             "owers": [
                 {"activated": True, "id": 1, "name": "zorglub", "weight": 1},
-                {"activated": True, "id": 2, "name": "fred", "weight": 1},
+                {"activated": True, "id": 2, "name": "jeanne", "weight": 1},
             ],
             "amount": 25.0,
             "date": "2011-08-10",
@@ -498,7 +498,7 @@ class TestAPI(IhatemoneyTestCase):
             "payer_id": 2,
             "owers": [
                 {"activated": True, "id": 1, "name": "zorglub", "weight": 1},
-                {"activated": True, "id": 2, "name": "fred", "weight": 1},
+                {"activated": True, "id": 2, "name": "jeanne", "weight": 1},
             ],
             "amount": 25.0,
             "date": "2011-09-10",
@@ -534,7 +534,7 @@ class TestAPI(IhatemoneyTestCase):
 
         # add participants
         self.api_add_member("raclette", "zorglub")
-        self.api_add_member("raclette", "fred")
+        self.api_add_member("raclette", "jeanne")
 
         # valid amounts
         input_expected = [
@@ -576,7 +576,7 @@ class TestAPI(IhatemoneyTestCase):
                 "payer_id": 1,
                 "owers": [
                     {"activated": True, "id": 1, "name": "zorglub", "weight": 1},
-                    {"activated": True, "id": 2, "name": "fred", "weight": 1},
+                    {"activated": True, "id": 2, "name": "jeanne", "weight": 1},
                 ],
                 "amount": expected_amount,
                 "date": "2011-08-10",
@@ -647,7 +647,7 @@ class TestAPI(IhatemoneyTestCase):
 
         # Add participants
         self.api_add_member("raclette", "zorglub")
-        self.api_add_member("raclette", "fred")
+        self.api_add_member("raclette", "jeanne")
         self.api_add_member("raclette", "quentin")
 
         # Add a bill without explicit currency
@@ -680,7 +680,7 @@ class TestAPI(IhatemoneyTestCase):
             "payer_id": 1,
             "owers": [
                 {"activated": True, "id": 1, "name": "zorglub", "weight": 1},
-                {"activated": True, "id": 2, "name": "fred", "weight": 1},
+                {"activated": True, "id": 2, "name": "jeanne", "weight": 1},
             ],
             "amount": 25.0,
             "date": "2011-08-10",
@@ -725,7 +725,7 @@ class TestAPI(IhatemoneyTestCase):
             "payer_id": 1,
             "owers": [
                 {"activated": True, "id": 1, "name": "zorglub", "weight": 1.0},
-                {"activated": True, "id": 2, "name": "fred", "weight": 1.0},
+                {"activated": True, "id": 2, "name": "jeanne", "weight": 1.0},
             ],
             "amount": 30.0,
             "date": "2011-08-10",
@@ -781,7 +781,7 @@ class TestAPI(IhatemoneyTestCase):
 
         # add participants
         self.api_add_member("raclette", "zorglub")
-        self.api_add_member("raclette", "fred")
+        self.api_add_member("raclette", "jeanne")
 
         # add a bill
         req = self.client.post(
@@ -818,7 +818,7 @@ class TestAPI(IhatemoneyTestCase):
                 "member": {
                     "activated": True,
                     "id": 2,
-                    "name": "fred",
+                    "name": "jeanne",
                     "weight": 1.0,
                 },
                 "paid": 0,
@@ -844,7 +844,7 @@ class TestAPI(IhatemoneyTestCase):
 
         # add participants
         self.api_add_member("raclette", "zorglub")
-        self.api_add_member("raclette", "freddy familly", 4)
+        self.api_add_member("raclette", "jeannedy familly", 4)
         self.api_add_member("raclette", "quentin")
 
         # add a bill
@@ -875,7 +875,7 @@ class TestAPI(IhatemoneyTestCase):
             "payer_id": 1,
             "owers": [
                 {"activated": True, "id": 1, "name": "zorglub", "weight": 1},
-                {"activated": True, "id": 2, "name": "freddy familly", "weight": 4},
+                {"activated": True, "id": 2, "name": "jeannedy familly", "weight": 4},
             ],
             "amount": 25.0,
             "date": "2011-08-10",
@@ -909,7 +909,7 @@ class TestAPI(IhatemoneyTestCase):
                 {
                     "activated": True,
                     "id": 2,
-                    "name": "freddy familly",
+                    "name": "jeannedy familly",
                     "weight": 4.0,
                     "balance": -20.0,
                 },

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -400,25 +400,25 @@ class TestBudget(IhatemoneyTestCase):
         # should not accept him
         assert len(self.get_project("raclette").members) == 1
 
-        # add fred
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        # add jeanne
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         assert len(self.get_project("raclette").members) == 2
 
-        # check fred is present in the bills page
+        # check jeanne is present in the bills page
         result = self.client.get("/raclette/")
-        assert "fred" in result.data.decode("utf-8")
+        assert "jeanne" in result.data.decode("utf-8")
 
-        # remove fred
+        # remove jeanne
         self.client.post(
             "/raclette/members/%s/delete" % self.get_project("raclette").members[-1].id
         )
 
-        # as fred is not bound to any bill, he is removed
+        # as jeanne is not bound to any bill, he is removed
         assert len(self.get_project("raclette").members) == 1
 
-        # add fred again
-        self.client.post("/raclette/members/add", data={"name": "fred"})
-        fred_id = self.get_project("raclette").members[-1].id
+        # add jeanne again
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
+        jeanne_id = self.get_project("raclette").members[-1].id
 
         # bound him to a bill
         result = self.client.post(
@@ -426,38 +426,38 @@ class TestBudget(IhatemoneyTestCase):
             data={
                 "date": "2011-08-10",
                 "what": "fromage à raclette",
-                "payer": fred_id,
-                "payed_for": [fred_id],
+                "payer": jeanne_id,
+                "payed_for": [jeanne_id],
                 "amount": "25",
             },
         )
 
-        # remove fred
-        self.client.post(f"/raclette/members/{fred_id}/delete")
+        # remove jeanne
+        self.client.post(f"/raclette/members/{jeanne_id}/delete")
 
         # he is still in the database, but is deactivated
         assert len(self.get_project("raclette").members) == 2
         assert len(self.get_project("raclette").active_members) == 1
 
-        # as fred is now deactivated, check that he is not listed when adding
+        # as jeanne is now deactivated, check that he is not listed when adding
         # a bill or displaying the balance
         result = self.client.get("/raclette/")
-        assert (f"/raclette/members/{fred_id}/delete") not in result.data.decode(
+        assert (f"/raclette/members/{jeanne_id}/delete") not in result.data.decode(
             "utf-8"
         )
 
         result = self.client.get("/raclette/add")
-        assert "fred" not in result.data.decode("utf-8")
+        assert "jeanne" not in result.data.decode("utf-8")
 
         # adding him again should reactivate him
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         assert len(self.get_project("raclette").active_members) == 2
 
         # adding an user with the same name as another user from a different
         # project should not cause any troubles
         self.post_project("randomid")
         self.login("randomid")
-        self.client.post("/randomid/members/add", data={"name": "fred"})
+        self.client.post("/randomid/members/add", data={"name": "jeanne"})
         assert len(self.get_project("randomid").active_members) == 1
 
     def test_person_model(self):
@@ -634,7 +634,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add two participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
 
         members_ids = [m.id for m in self.get_project("raclette").members]
 
@@ -776,7 +776,7 @@ class TestBudget(IhatemoneyTestCase):
         # add two participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
         self.client.post(
-            "/raclette/members/add", data={"name": "freddy familly", "weight": 4}
+            "/raclette/members/add", data={"name": "jeannedy familly", "weight": 4}
         )
 
         members_ids = [m.id for m in self.get_project("raclette").members]
@@ -828,7 +828,7 @@ class TestBudget(IhatemoneyTestCase):
         assert "extra-info" in resp.data.decode("utf-8")
 
         self.client.post(
-            "/raclette/members/add", data={"name": "freddy familly", "weight": 4}
+            "/raclette/members/add", data={"name": "jeannedy familly", "weight": 4}
         )
 
         resp = self.client.get("/raclette/")
@@ -853,7 +853,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
 
         # create bills
@@ -993,7 +993,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         # Add a participant with a balance at 0 :
         self.client.post("/raclette/members/add", data={"name": "pépé"})
@@ -1052,7 +1052,8 @@ class TestBudget(IhatemoneyTestCase):
             response.data.decode("utf-8"),
         )
         assert re.search(
-            regex.format("fred", r"\$20\.00", r"\$5\.83"), response.data.decode("utf-8")
+            regex.format("jeanne", r"\$20\.00", r"\$5\.83"),
+            response.data.decode("utf-8"),
         )
         assert re.search(
             regex.format("tata", r"\$0\.00", r"\$2\.50"), response.data.decode("utf-8")
@@ -1063,7 +1064,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # Check that the order of participants in the sidebar table is the
         # same as in the main table.
-        order = ["fred", "pépé", "tata", "zorglub"]
+        order = ["jeanne", "pépé", "tata", "zorglub"]
         regex1 = r".*".join(
             r"<td class=\"balance-name\">{}</td>".format(name) for name in order
         )
@@ -1178,7 +1179,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         # Add a participant with a balance at 0 :
         self.client.post("/raclette/members/add", data={"name": "pépé"})
@@ -1233,7 +1234,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
 
         # create bills
@@ -1286,7 +1287,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # Add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         self.client.post("/raclette/members/add", data={"name": "pépé"})
 
@@ -1410,7 +1411,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
 
         # create bills
@@ -1537,7 +1538,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
 
         # Bill with a different currency than project's default
         self.client.post(
@@ -1572,7 +1573,7 @@ class TestBudget(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
 
         # Bills with a different currency than project's default
         self.client.post(
@@ -1647,13 +1648,15 @@ class TestBudget(IhatemoneyTestCase):
             "/raclette/members/add", data={"name": "zorglub", "weight": 1.0}
         )
         self.client.post("/raclette/members/add", data={"name": "tata", "weight": 1.10})
-        self.client.post("/raclette/members/add", data={"name": "fred", "weight": 1.15})
+        self.client.post(
+            "/raclette/members/add", data={"name": "jeanne", "weight": 1.15}
+        )
 
         # check if weights of the users are 1, 1.1, 1.15 respectively
         resp = self.client.get("/raclette/")
         assert 'zorglub<span class="light">(x1)</span>' in resp.data.decode("utf-8")
         assert 'tata<span class="light">(x1.1)</span>' in resp.data.decode("utf-8")
-        assert 'fred<span class="light">(x1.15)</span>' in resp.data.decode("utf-8")
+        assert 'jeanne<span class="light">(x1.15)</span>' in resp.data.decode("utf-8")
 
     def test_amount_too_high(self):
         self.post_project("raclette")
@@ -2060,7 +2063,7 @@ class TestBudget(IhatemoneyTestCase):
         """
         self.post_project("raclette")
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         members_ids = [m.id for m in self.get_project("raclette").members]
         # create a bill
         self.client.post(
@@ -2110,7 +2113,7 @@ class TestBudget(IhatemoneyTestCase):
         """
         self.post_project("raclette")
         self.client.post("/raclette/members/add", data={"name": "zorglub"})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "pipistrelle"})
         members_ids = [m.id for m in self.get_project("raclette").members]
         # create a bill

--- a/ihatemoney/tests/import_test.py
+++ b/ihatemoney/tests/import_test.py
@@ -16,13 +16,13 @@ def import_data(request: pytest.FixtureRequest):
             "amount": 13.33,
             "payer_name": "tata",
             "payer_weight": 1.0,
-            "owers": ["fred"],
+            "owers": ["jeanne"],
         },
         {
             "date": "2016-12-31",
             "what": "red wine",
             "amount": 200.0,
-            "payer_name": "fred",
+            "payer_name": "jeanne",
             "payer_weight": 1.0,
             "owers": ["zorglub", "tata"],
         },
@@ -32,7 +32,7 @@ def import_data(request: pytest.FixtureRequest):
             "amount": 10.0,
             "payer_name": "zorglub",
             "payer_weight": 2.0,
-            "owers": ["zorglub", "fred", "tata", "pepe"],
+            "owers": ["zorglub", "jeanne", "tata", "pepe"],
         },
     ]
     request.cls.data = data
@@ -51,13 +51,13 @@ class CommonTestCase(object):
                     "amount": 13.33,
                     "payer_name": "tata",
                     "payer_weight": 1.0,
-                    "owers": ["fred"],
+                    "owers": ["jeanne"],
                 },
                 {
                     "date": "2016-12-31",
                     "what": "red wine",
                     "amount": 200.0,
-                    "payer_name": "fred",
+                    "payer_name": "jeanne",
                     "payer_weight": 1.0,
                     "owers": ["zorglub", "tata"],
                 },
@@ -67,7 +67,7 @@ class CommonTestCase(object):
                     "amount": 10.0,
                     "payer_name": "zorglub",
                     "payer_weight": 2.0,
-                    "owers": ["zorglub", "fred", "tata", "pepe"],
+                    "owers": ["zorglub", "jeanne", "tata", "pepe"],
                 },
             ]
 
@@ -264,7 +264,7 @@ class CommonTestCase(object):
             self.client.post(
                 "/raclette/members/add", data={"name": "zorglub", "weight": 2}
             )
-            self.client.post("/raclette/members/add", data={"name": "fred"})
+            self.client.post("/raclette/members/add", data={"name": "jeanne"})
             self.client.post("/raclette/members/add", data={"name": "tata"})
             self.client.post(
                 "/raclette/add",
@@ -328,7 +328,7 @@ class CommonTestCase(object):
                     "what": "refund",
                     "payer_name": "tata",
                     "payer_weight": 1.0,
-                    "owers": ["fred"],
+                    "owers": ["jeanne"],
                 }
             ]
             for data in [data_wrong_keys, data_amount_missing]:
@@ -344,7 +344,7 @@ class TestExport(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         self.client.post("/raclette/members/add", data={"name": "pépé"})
 
@@ -392,14 +392,14 @@ class TestExport(IhatemoneyTestCase):
                 "currency": "XXX",
                 "payer_name": "tata",
                 "payer_weight": 1.0,
-                "owers": ["fred"],
+                "owers": ["jeanne"],
             },
             {
                 "date": "2016-12-31",
                 "what": "red wine",
                 "amount": 200.0,
                 "currency": "XXX",
-                "payer_name": "fred",
+                "payer_name": "jeanne",
                 "payer_weight": 1.0,
                 "owers": ["zorglub", "tata"],
             },
@@ -410,7 +410,7 @@ class TestExport(IhatemoneyTestCase):
                 "currency": "XXX",
                 "payer_name": "zorglub",
                 "payer_weight": 2.0,
-                "owers": ["zorglub", "fred", "tata", "p\xe9p\xe9"],
+                "owers": ["zorglub", "jeanne", "tata", "p\xe9p\xe9"],
             },
         ]
         assert json.loads(resp.data.decode("utf-8")) == expected
@@ -419,9 +419,9 @@ class TestExport(IhatemoneyTestCase):
         resp = self.client.get("/raclette/export/bills.csv")
         expected = [
             "date,what,amount,currency,payer_name,payer_weight,owers",
-            "2017-01-01,refund,XXX,13.33,tata,1.0,fred",
-            '2016-12-31,red wine,XXX,200.0,fred,1.0,"zorglub, tata"',
-            '2016-12-31,fromage à raclette,10.0,XXX,zorglub,2.0,"zorglub, fred, tata, pépé"',
+            "2017-01-01,refund,XXX,13.33,tata,1.0,jeanne",
+            '2016-12-31,red wine,XXX,200.0,jeanne,1.0,"zorglub, tata"',
+            '2016-12-31,fromage à raclette,10.0,XXX,zorglub,2.0,"zorglub, jeanne, tata, pépé"',
         ]
         received_lines = resp.data.decode("utf-8").split("\n")
 
@@ -434,14 +434,14 @@ class TestExport(IhatemoneyTestCase):
             {
                 "amount": 2.00,
                 "currency": "XXX",
-                "receiver": "fred",
+                "receiver": "jeanne",
                 "ower": "p\xe9p\xe9",
             },
-            {"amount": 55.34, "currency": "XXX", "receiver": "fred", "ower": "tata"},
+            {"amount": 55.34, "currency": "XXX", "receiver": "jeanne", "ower": "tata"},
             {
                 "amount": 127.33,
                 "currency": "XXX",
-                "receiver": "fred",
+                "receiver": "jeanne",
                 "ower": "zorglub",
             },
         ]
@@ -453,9 +453,9 @@ class TestExport(IhatemoneyTestCase):
 
         expected = [
             "amount,currency,receiver,ower",
-            "2.0,XXX,fred,pépé",
-            "55.34,XXX,fred,tata",
-            "127.33,XXX,fred,zorglub",
+            "2.0,XXX,jeanne,pépé",
+            "55.34,XXX,jeanne,tata",
+            "127.33,XXX,jeanne,zorglub",
         ]
         received_lines = resp.data.decode("utf-8").split("\n")
 
@@ -472,7 +472,7 @@ class TestExport(IhatemoneyTestCase):
 
         # add participants
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         self.client.post("/raclette/members/add", data={"name": "pépé"})
 
@@ -523,14 +523,14 @@ class TestExport(IhatemoneyTestCase):
                 "currency": "EUR",
                 "payer_name": "tata",
                 "payer_weight": 1.0,
-                "owers": ["fred"],
+                "owers": ["jeanne"],
             },
             {
                 "date": "2016-12-31",
                 "what": "poutine from Qu\xe9bec",
                 "amount": 100.0,
                 "currency": "CAD",
-                "payer_name": "fred",
+                "payer_name": "jeanne",
                 "payer_weight": 1.0,
                 "owers": ["zorglub", "tata"],
             },
@@ -541,7 +541,7 @@ class TestExport(IhatemoneyTestCase):
                 "currency": "EUR",
                 "payer_name": "zorglub",
                 "payer_weight": 2.0,
-                "owers": ["zorglub", "fred", "tata", "p\xe9p\xe9"],
+                "owers": ["zorglub", "jeanne", "tata", "p\xe9p\xe9"],
             },
         ]
         assert json.loads(resp.data.decode("utf-8")) == expected
@@ -550,9 +550,9 @@ class TestExport(IhatemoneyTestCase):
         resp = self.client.get("/raclette/export/bills.csv")
         expected = [
             "date,what,amount,currency,payer_name,payer_weight,owers",
-            "2017-01-01,refund,13.33,EUR,tata,1.0,fred",
-            '2016-12-31,poutine from Québec,100.0,CAD,fred,1.0,"zorglub, tata"',
-            '2016-12-31,fromage à raclette,10.0,EUR,zorglub,2.0,"zorglub, fred, tata, pépé"',
+            "2017-01-01,refund,13.33,EUR,tata,1.0,jeanne",
+            '2016-12-31,poutine from Québec,100.0,CAD,jeanne,1.0,"zorglub, tata"',
+            '2016-12-31,fromage à raclette,10.0,EUR,zorglub,2.0,"zorglub, jeanne, tata, pépé"',
         ]
         received_lines = resp.data.decode("utf-8").split("\n")
 
@@ -565,11 +565,16 @@ class TestExport(IhatemoneyTestCase):
             {
                 "amount": 2.00,
                 "currency": "EUR",
-                "receiver": "fred",
+                "receiver": "jeanne",
                 "ower": "p\xe9p\xe9",
             },
-            {"amount": 10.89, "currency": "EUR", "receiver": "fred", "ower": "tata"},
-            {"amount": 38.45, "currency": "EUR", "receiver": "fred", "ower": "zorglub"},
+            {"amount": 10.89, "currency": "EUR", "receiver": "jeanne", "ower": "tata"},
+            {
+                "amount": 38.45,
+                "currency": "EUR",
+                "receiver": "jeanne",
+                "ower": "zorglub",
+            },
         ]
 
         assert json.loads(resp.data.decode("utf-8")) == expected
@@ -579,9 +584,9 @@ class TestExport(IhatemoneyTestCase):
 
         expected = [
             "amount,currency,receiver,ower",
-            "2.0,EUR,fred,pépé",
-            "10.89,EUR,fred,tata",
-            "38.45,EUR,fred,zorglub",
+            "2.0,EUR,jeanne,pépé",
+            "10.89,EUR,jeanne,tata",
+            "38.45,EUR,jeanne,zorglub",
         ]
         received_lines = resp.data.decode("utf-8").split("\n")
 
@@ -598,11 +603,16 @@ class TestExport(IhatemoneyTestCase):
             {
                 "amount": 3.00,
                 "currency": "CAD",
-                "receiver": "fred",
+                "receiver": "jeanne",
                 "ower": "p\xe9p\xe9",
             },
-            {"amount": 16.34, "currency": "CAD", "receiver": "fred", "ower": "tata"},
-            {"amount": 57.67, "currency": "CAD", "receiver": "fred", "ower": "zorglub"},
+            {"amount": 16.34, "currency": "CAD", "receiver": "jeanne", "ower": "tata"},
+            {
+                "amount": 57.67,
+                "currency": "CAD",
+                "receiver": "jeanne",
+                "ower": "zorglub",
+            },
         ]
 
         assert json.loads(resp.data.decode("utf-8")) == expected
@@ -612,9 +622,9 @@ class TestExport(IhatemoneyTestCase):
 
         expected = [
             "amount,currency,receiver,ower",
-            "3.0,CAD,fred,pépé",
-            "16.34,CAD,fred,tata",
-            "57.67,CAD,fred,zorglub",
+            "3.0,CAD,jeanne,pépé",
+            "16.34,CAD,jeanne,tata",
+            "57.67,CAD,jeanne,zorglub",
         ]
         received_lines = resp.data.decode("utf-8").split("\n")
 

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -113,7 +113,7 @@ class TestModels(IhatemoneyTestCase):
 
         # add members
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         # Add a member with a balance=0 :
         self.client.post("/raclette/members/add", data={"name": "pépé"})
@@ -168,7 +168,7 @@ class TestModels(IhatemoneyTestCase):
 
         # add members
         self.client.post("/raclette/members/add", data={"name": "zorglub", "weight": 2})
-        self.client.post("/raclette/members/add", data={"name": "fred"})
+        self.client.post("/raclette/members/add", data={"name": "jeanne"})
         self.client.post("/raclette/members/add", data={"name": "tata"})
         # Add a member with a balance=0 :
         self.client.post("/raclette/members/add", data={"name": "pépé"})


### PR DESCRIPTION
Swapping ‘Fred’ for ‘Jeanne’ across our docs and API.

Here’s the lowdown - 'Fred' and I ... we've got history. It's the kind of backstory that doesn't really gel with my day-to-day code jams. Every time I bump into 'Fred' in our project, it’s like a weird little jingle that gets stuck in my head – not the fun kind. So, I’m trading it out for 'Jeanne,' which is just a way chiller vibe for me.

But no worries, I’ve double-checked this swap, making sure it’s all smooth:
- All the 'Fred' references in the docs have waved goodbye, and 'Jeanne' has warmly taken their spot.
- If 'Fred' had a cameo in any comments, tests, or examples, 'Jeanne' is now nailing the audition instead.
- Gave the whole thing a once-over (then a twice-over) to catch any sneaky 'Fred' stragglers.

This isn’t about flipping tables – it’s all about keeping the code kitchen a place where we’re all comfy cooking up our projects. I’m sure you’ll find 'Jeanne' to be a pretty seamless switcheroo.

Ping me if things look off or you just wanna chat about it. Thanks for being the kind of crew that's cool with these little tweaks. It means a lot. 🌟