### PR TITLE
Fix APPLICATION_ROOT example in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ ADMIN_PASSWORD needs to be set.
 
 ## APPLICATION_ROOT
 
-If empty, ihatemoney will be served at domain root (e.g:
+By default, ihatemoney will be served at domain root (e.g:
 *http://domain.tld*), if set to `"/somestring"`, it will be served from a
 "folder" (e.g: *http://domain.tld/somestring*).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,10 +128,10 @@ ADMIN_PASSWORD needs to be set.
 ## APPLICATION_ROOT
 
 If empty, ihatemoney will be served at domain root (e.g:
-*http://domain.tld*), if set to `"somestring"`, it will be served from a
+*http://domain.tld*), if set to `"/somestring"`, it will be served from a
 "folder" (e.g: *http://domain.tld/somestring*).
 
--   **Default value:** `""` (empty string)
+-   **Default value:** `"/"`
 
 ## BABEL_DEFAULT_TIMEZONE
 


### PR DESCRIPTION
If the application is hosted on the path `/somestring`, static asset paths need to have prefix `/somestring/static/` but setting `APPLICATION_ROOT` to "somestring" will result in a relative path which will give a 4XX. Using "/somestring" fixes this.

e.g. static assets should look like this in source:

```html
<link rel="stylesheet" type="text/css" href="/somestring/static/css/main.css">
```

but without the leading slash they have `href="somestring/static/css/main.css"` which results in a network request for `{DOMAIN}/somestring/{PROJECT_NAME}/somestring/static/css/main.css`

The test suite includes the leading slash in `test_prefixed`:

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/ihatemoney/tests/main_test.py#L76-L77

---

Also fix default value, which is "/" and not the empty string:

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/ihatemoney/default_settings.py#L13

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/Dockerfile#L29

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/docker-compose.yml#L38

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/ihatemoney/conf-templates/ihatemoney.cfg.j2#L50-L51

https://github.com/spiral-project/ihatemoney/blob/76e8b3baf0b52d098c1287f01ebf30cdeeb6ecc5/ihatemoney/tests/main_test.py#L72