### PR TITLE
Fix missing markdown include in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include *.rst
-recursive-include ihatemoney *.rst *.py *.yaml *.po *.mo *.html *.css *.js *.eot *.svg *.woff *.txt *.png *.webp *.ini *.cfg *.j2 *.jpg *.gif *.ico *.xml
-include LICENSE CONTRIBUTORS CHANGELOG.rst
+include *.md
+recursive-include ihatemoney *.py *.yaml *.po *.mo *.html *.css *.js *.eot *.svg *.woff *.txt *.png *.webp *.ini *.cfg *.j2 *.jpg *.gif *.ico *.xml
+include LICENSE CONTRIBUTORS


### PR DESCRIPTION
Since moving from ReST to Markdown, we forgot to update the manifest to include Markdown files.  It means that files such as README.md and CHANGELOG.md are missing from releases.  In practice, this broke the description on PyPI:

https://pypi.org/project/ihatemoney/6.1.3/