### PR TITLE
[chore] Remove deprecated Jinja2 extensions.

### DIFF
--- a/ihatemoney/babel.cfg
+++ b/ihatemoney/babel.cfg
@@ -1,3 +1,2 @@
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_


### PR DESCRIPTION
autoescape and with extensions are now built-in
to the Jinja2 compiler since v3.

See https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-0-0
