### PR TITLE
 Fixing the issue of Chinese character garbled encoding in CSV export.

### DIFF
--- a/ihatemoney/tests/import_test.py
+++ b/ihatemoney/tests/import_test.py
@@ -423,7 +423,7 @@ class TestExport(IhatemoneyTestCase):
             '2016-12-31,red wine,XXX,200.0,jeanne,1.0,"zorglub, tata"',
             '2016-12-31,fromage à raclette,10.0,XXX,zorglub,2.0,"zorglub, jeanne, tata, pépé"',
         ]
-        received_lines = resp.data.decode("utf-8").split("\n")
+        received_lines = resp.data.decode("utf-8-sig").split("\n")
 
         for i, line in enumerate(expected):
             assert set(line.split(",")) == set(received_lines[i].strip("\r").split(","))
@@ -457,7 +457,7 @@ class TestExport(IhatemoneyTestCase):
             "55.34,XXX,jeanne,tata",
             "127.33,XXX,jeanne,zorglub",
         ]
-        received_lines = resp.data.decode("utf-8").split("\n")
+        received_lines = resp.data.decode("utf-8-sig").split("\n")
 
         for i, line in enumerate(expected):
             assert set(line.split(",")) == set(received_lines[i].strip("\r").split(","))
@@ -656,7 +656,7 @@ class TestExport(IhatemoneyTestCase):
             "date,what,amount,currency,payer_name,payer_weight,owers",
             "2016-12-31,'=COS(36),10.0,EUR,zorglub,1.0,zorglub",
         ]
-        received_lines = resp.data.decode("utf-8").split("\n")
+        received_lines = resp.data.decode("utf-8-sig").split("\n")
 
         for i, line in enumerate(expected):
             assert set(line.split(",")) == set(received_lines[i].strip("\r").split(","))

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -196,7 +196,7 @@ def list_of_dicts2csv(dict_to_convert):
     writer = csv.writer(csv_file)
     writer.writerows(csv_data)
     csv_file.seek(0)
-    csv_file = BytesIO(csv_file.getvalue().encode("utf-8"))
+    csv_file = BytesIO(csv_file.getvalue().encode("utf-8-sig"))
     return csv_file
 
 

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -204,7 +204,7 @@ def csv2list_of_dicts(csv_to_convert):
     """Take a csv in-memory file and turns it into
     a list of dictionnaries
     """
-    csv_file = TextIOWrapper(csv_to_convert, encoding="utf-8")
+    csv_file = TextIOWrapper(csv_to_convert, encoding="utf-8-sig")
     reader = csv.DictReader(csv_file)
     result = []
     for r in reader:


### PR DESCRIPTION
**Fixing the issue of garbled characters (Chinese characters) when opening the CSV export in Microsoft Excel.**
Using version 6.1.3 and opening CSV export files with Chinese content by default in Microsoft Excel in a Chinese environment results in garbled characters due to encoding issues, as shown in the image (the top part is the current version export, and the bottom part is the export after fixing).
<img width="729" alt="Snipaste_2024-02-04_14-31-15" src="https://github.com/spiral-project/ihatemoney/assets/36438412/04b768e6-498e-4aa6-a7da-6d3f7c32dbf5">