### PR TITLE
Changing any settings is prevented when project has existing currency

### DIFF
--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -195,7 +195,7 @@ class EditProjectForm(FlaskForm):
             raise ValidationError(msg)
         if (
             project is not None
-            and field.data != CurrencyConverter.no_currency
+            and field.data != project.default_currency
             and project.has_bills()
         ):
             msg = _(


### PR DESCRIPTION
This PR fixes #1291. 

# Summary of the issue
It's a small fix to a small annoying bug : when a project as some bills, a default currency (different than "XXX") and you want to change the project settings an error message is shown : "Cannot change project currency because currency conversion is broken". The only way to change the project settings is then to remove the currency (set to "XXX"). Therefore, the error message is not constant with the behavior.

# The new behavior
The default currency field is check against the current project default currency. If the project has bills and the new input default currency doesn't match the current one, the error "Cannot change project currency because currency conversion is broken" is shown. 
I have tested the behavior. This is true for the API as well as the GUI input.