### PR TITLE
Requested billtype changes

### DIFF
--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -716,19 +716,7 @@ class TestBudget(IhatemoneyTestCase):
                 "amount": "17",
             },
         )
-
-        # transfer bill should not affect balances at all
-        self.client.post(
-            "/raclette/add",
-            data={
-                "date": "2011-08-10",
-                "what": "Transfer",
-                "payer": members_ids[1],
-                "payed_for": members_ids[0],
-                "bill_type": "Transfer",
-                "amount": "500",
-            },
-        )
+        
         balance = self.get_project("raclette").balance
         assert set(balance.values()) == set([19.0, -19.0])
 

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -716,7 +716,7 @@ class TestBudget(IhatemoneyTestCase):
                 "amount": "17",
             },
         )
-        
+
         balance = self.get_project("raclette").balance
         assert set(balance.values()) == set([19.0, -19.0])
 

--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -843,40 +843,6 @@ class TestBudget(IhatemoneyTestCase):
         assert bob_paid == 500
         assert alice_paid == 500
 
-    def test_transfer_bill(self):
-        self.post_project("random")
-
-        # add two participants
-        self.client.post("/random/members/add", data={"name": "zorglub"})
-        self.client.post("/random/members/add", data={"name": "fred"})
-
-        members_ids = [m.id for m in self.get_project("random").members]
-        self.client.post(
-            "/random/add",
-            data={
-                "date": "2022-10-10",
-                "what": "Rent",
-                "payer": members_ids[0],  # zorglub
-                "payed_for": members_ids,  # zorglub + fred
-                "bill_type": "Expense",
-                "amount": "1000",
-            },
-        )
-        # test transfer bill (should not affect anything whatsoever)
-        self.client.post(
-            "/random/add",
-            data={
-                "date": "2022-10-10",
-                "what": "Transfer of 500 to fred",
-                "payer": members_ids[0],  # zorglub
-                "payed_for": members_ids[1],  # fred
-                "bill_type": "Transfer",
-                "amount": "500",
-            },
-        )
-        balance = self.get_project("random").balance
-        assert set(balance.values()), set([500 == -500])
-
     def test_weighted_balance(self):
         self.post_project("raclette")
 

--- a/ihatemoney/tests/import_test.py
+++ b/ihatemoney/tests/import_test.py
@@ -560,7 +560,7 @@ class TestExport(IhatemoneyTestCase):
             },
             {
                 "date": "2016-12-31",
-                "what": "\xe0 raclette",
+                "what": "fromage \xe0 raclette",
                 "bill_type": "Expense",
                 "amount": 10.0,
                 "currency": "EUR",

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -852,8 +852,6 @@ def settle_bill():
 
 @main.route("/<project_id>/settle/<amount>/<int:ower_id>/<int:payer_id>")
 def settle(amount, ower_id, payer_id):
-    # FIXME: Test this bill belongs to this project !
-
     new_reinbursement = Bill(
         amount=float(amount),
         date=datetime.datetime.today(),


### PR DESCRIPTION
This PR contains the changes requested after PR #1290 was merged. It contains only pretty minor changes.
Specifically this PR contains the following:
 - Some tests contained leftover references to the "Transfer" type, these were removed. Also one test specifically checking the "Transfer" type has been completely removed.
   - The actual terminology might change depending on the discussion in #1299 
 - The `web.settle` route contained a "FIXME" comment. Looking into it, I think it was previously erroneously copied from `edit_bill` in web.py:811. It doesn't need to check if the bill belongs to the requested project as this function creates that bill itself.
 - In one of the tests, "fromage" was removed. This erasure has been undone, and the vibes of the codebase have been improved.
 - A test was requested for the `web.settle` route, however this route is already being tested in `budget_test.py:1309`, `test_settle_button`. In this test, the settle route is called and checked. So no new test was added.

@zorun, I think that was everything you asked back in #1290? Let me know if there is anything I missed!