### PR TITLE
Workaround to avoid history bug #1324

### DIFF
--- a/ihatemoney/history.py
+++ b/ihatemoney/history.py
@@ -38,7 +38,7 @@ def history_sort_key(history_item_dict):
 
 def describe_version(version_obj):
     """Use the base model str() function to describe a version object"""
-    if version_obj is None:
+    if not version_obj:
         return ""
     else:
         return parent_class(type(version_obj)).__str__(version_obj)

--- a/ihatemoney/history.py
+++ b/ihatemoney/history.py
@@ -38,7 +38,10 @@ def history_sort_key(history_item_dict):
 
 def describe_version(version_obj):
     """Use the base model str() function to describe a version object"""
-    return parent_class(type(version_obj)).__str__(version_obj)
+    if version_obj is None:
+        return ""
+    else:
+        return parent_class(type(version_obj)).__str__(version_obj)
 
 
 def describe_owers_change(version, human_readable_names):


### PR DESCRIPTION
This is a poor workaround to bug #1324.
It does not solve the issue but at least it avoid the "Internal server error", which is nice.

Now the bills for which payer or ower are not well versioned seem to:
![image](https://github.com/user-attachments/assets/c823ded2-e016-4691-ae29-6cd045850f4b)

If anyone has the same issue as me, I found a trick to make members well versioned: deactivate and reactivate them. The bills recorded afterward are well versioned.