### PR TITLE
Move the bill type field in the More options section

### DIFF
--- a/ihatemoney/templates/forms.html
+++ b/ihatemoney/templates/forms.html
@@ -165,7 +165,6 @@
     {% include "display_errors.html" %}
     {{ form.hidden_tag() }}
     {{ input(form.date, inline=True) }}
-    {{ input(form.bill_type, inline=True) }}
     {{ input(form.what, inline=True) }}
     {{ input(form.payer, inline=True, class="form-control custom-select") }}
     <div data-toggle="tooltip" data-placement="top" title='{{ _("Simple operations are allowed, e.g. (18+36.2)/3") }}'>
@@ -201,6 +200,7 @@
         {% if g.project.default_currency != "XXX" %}
             {{ input(form.original_currency, inline=True, class="form-control custom-select") }}
         {% endif %}
+        {{ input(form.bill_type, inline=True) }}
         {{ input(form.external_link, inline=True) }}
     </details>
     </fieldset>


### PR DESCRIPTION
The "Bill type" field shouldn't be better placed in the "More options" section? What do you think?

I feel that it makes the UI clearer:
![image](https://github.com/user-attachments/assets/68b991d1-b90f-4e26-9c73-9b8ba446b877)
![image](https://github.com/user-attachments/assets/b8b4ec2a-8416-44a2-a0e7-1c1adbad1a4f)

(works also in the /add and /edit pages)