### PR TITLE
Do not display deactivated users when their balance is really small

### DIFF
--- a/ihatemoney/templates/sidebar_table_layout.html
+++ b/ihatemoney/templates/sidebar_table_layout.html
@@ -11,7 +11,7 @@
         </tr>
       </thead>
     {%- endif %}
-    {%- for member in g.project.members | sort(attribute='name') if member.activated or balance[member.id]|round(2) != 0 %}
+    {%- for member in g.project.members | sort(attribute='name') if member.activated or balance[member.id]|round(2)|abs > 0.01 %}
       <tr id="bal-member-{{ member.id }}" action="{% if member.activated %}delete{% else %}reactivate{% endif %}">
         <td class="balance-name">{{ member.name }}
           {%- if show_weight -%}


### PR DESCRIPTION
Cases has been reported of rounding issues making deactivated users reapparing. This is due to the fact we're using floats (see #528 for details)

Fixes #1336