### PR TITLE
Allow custom configuration file location when using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN echo "**** install build dependencies ****" &&\
     apk add --no-cache \
     shadow \
     postgresql-libs && \
-    echo "**** create runtime folder ****" && \
-    mkdir -p /etc/ihatemoney &&\
     echo "**** install pip packages ****" && \
     pip install --no-cache-dir \
     gunicorn && \

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -3,7 +3,14 @@
 # Fail the whole script on the first failure.
 set -e
 
-cat <<EOF >/etc/ihatemoney/ihatemoney.cfg
+# Allow using custom config file path
+if [ -z "${IHATEMONEY_SETTINGS_FILE_PATH}" ];
+then
+  IHATEMONEY_SETTINGS_FILE_PATH=/etc/ihatemoney/ihatemoney.cfg;
+fi
+mkdir -p $(dirname $IHATEMONEY_SETTINGS_FILE_PATH)
+
+cat <<EOF >$IHATEMONEY_SETTINGS_FILE_PATH
 DEBUG = $DEBUG
 ACTIVATE_ADMIN_DASHBOARD = $ACTIVATE_ADMIN_DASHBOARD
 ACTIVATE_DEMO_PROJECT = $ACTIVATE_DEMO_PROJECT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ALLOW_PUBLIC_PROJECT_CREATION=True
       - BABEL_DEFAULT_TIMEZONE=UTC
       - GREENLET_TEST_CPP=no
+      - IHATEMONEY_SETTINGS_FILE_PATH=/etc/ihatemoney/ihatemoney.cfg
       - MAIL_DEFAULT_SENDER=Budget manager <admin@example.com>
       - MAIL_PASSWORD=
       - MAIL_PORT=25


### PR DESCRIPTION
I've been playing with AppArmor lately and have been restricting access to /etc in many systems.

Doing this with IHateMoney installed on a server is possible since the configuration file's location can be changed from /etc to somewhere else. However in IHateMoney's Docker image the ability to change the configuration file's location was not implemented, so access to /etc within the container was mandatory.

This pull request implements that feature using the same environment variable (**IHATEMONEY_SETTINGS_FILE_PATH**) as is documented here : https://ihatemoney.readthedocs.io/en/latest/configuration.html

**It allows the person running the containers to change the configuration's file location**, for example if they wish to deny access to /etc. This also makes the app's behaviour consistent between servers and docker containers.