### PR TITLE
fix: remove amounts owed if custom split

### DIFF
--- a/ihatemoney/messages.pot
+++ b/ihatemoney/messages.pot
@@ -775,6 +775,9 @@ msgstr ""
 msgid "%(amount)s each"
 msgstr ""
 
+msgid "Custom split"
+msgstr ""
+
 msgid "you sure?"
 msgstr ""
 

--- a/ihatemoney/templates/list_bills.html
+++ b/ihatemoney/templates/list_bills.html
@@ -2,9 +2,11 @@
 
 {%- macro weighted_bill_amount(bill, weights, currency=bill.original_currency, amount=bill.amount) %}
     {{ amount|currency(currency) }}
-    {%- if weights != 1.0 %}
+    {%- if weights != 1.0 and weights == bill.owers|length %}
         ({{ _("%(amount)s each", amount=(amount / weights)|currency(currency)) }})
-    {%- endif -%}
+    {%- else %}
+        ({{ _("Custom split") }})
+    {%- endif %}
 {% endmacro -%}
 
 {% block title %} - {{ g.project.name }}{% endblock %}


### PR DESCRIPTION
Hello there 👋 

I'm starting to use my spare time to contribute on some open projects, this would be the first one 🙌 

This should address the issue as described in #1380 . I simply removed the amounts owed when the number of participant does not match the weight of the bill.

Translations coming from Weblate seem to be blocked though, so not sure what to do here.

Cheers,