### PR TITLE
Fix DeprecatiounWarning on ast.Num

### DIFF
--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from sqlalchemy import orm
 from werkzeug.security import check_password_hash
+import pytest
 
 from ihatemoney import models
 from ihatemoney.currency_convertor import CurrencyConverter
@@ -14,6 +15,7 @@ from ihatemoney.manage import (
     get_project_count,
     password_hash,
 )
+from ihatemoney.utils import eval_arithmetic_expression
 from ihatemoney.run import load_configuration
 from ihatemoney.tests.common.ihatemoney_testcase import BaseTestCase, IhatemoneyTestCase
 
@@ -469,3 +471,13 @@ class TestCurrencyConverter:
             # is mocking EVERY instance of the class method. Too bad.
             rates = CurrencyConverter.get_rates(self.converter)
         assert rates == {CurrencyConverter.no_currency: 1}
+
+
+class TestUtils:
+    def test_eval_arithmetic_expression(self):
+        assert eval_arithmetic_expression("32.3") == 32.3
+        assert eval_arithmetic_expression("-(3+2/4*5-2)") == -3.5
+        with pytest.raises(ValueError):
+            eval_arithmetic_expression("32.3/")
+        with pytest.raises(ValueError):
+            eval_arithmetic_expression("coucouc")

--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -270,8 +270,8 @@ def eval_arithmetic_expression(expr):
             ast.USub: operator.neg,
         }
 
-        if isinstance(node, ast.Num):  # <number>
-            return node.n
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):  # <number>
+            return node.value
         elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
             return operators[type(node.op)](_eval(node.left), _eval(node.right))
         elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1


### PR DESCRIPTION
Work hardly started :upside_down_face: 

Note for later:
- changing API like `Person.query.get()` is **not** required to upgrade to SQLAlchemy 2.0. SQLA2 considers this deprecated, but did not remove the API, and this seems to remain [the normal way to query from flask-sqlalchemy](https://github.com/pallets-eco/flask-sqlalchemy/issues/1010).