### PR TITLE
Fix currency conversion by switching to working exchange rate API

### DIFF
--- a/ihatemoney/currency_convertor.py
+++ b/ihatemoney/currency_convertor.py
@@ -17,7 +17,7 @@ class Singleton(type):
 class CurrencyConverter(object, metaclass=Singleton):
     # Get exchange rates
     no_currency = "XXX"
-    api_url = "https://api.exchangerate.host/latest?base=USD"
+    api_url = "https://open.er-api.com/v6/latest/USD"
 
     def __init__(self):
         pass

--- a/ihatemoney/forms.py
+++ b/ihatemoney/forms.py
@@ -428,15 +428,15 @@ class BillForm(FlaskForm):
             raise ValidationError(f"Result is too high: {field.data}")
 
     def validate_original_currency(self, field):
-        # Workaround for currency API breakage
-        # See #1232
         if field.data not in [CurrencyConverter.no_currency, self.project_currency]:
-            msg = _(
-                "Failed to convert from %(bill_currency)s currency to %(project_currency)s",
-                bill_currency=field.data,
-                project_currency=self.project_currency,
-            )
-            raise ValidationError(msg)
+            rates = self.currency_helper.get_rates()
+            if not rates or field.data not in rates:
+                msg = _(
+                    "Failed to convert from %(bill_currency)s currency to %(project_currency)s",
+                    bill_currency=field.data,
+                    project_currency=self.project_currency,
+                )
+                raise ValidationError(msg)
 
 
 class HiddenCommaDecimalField(HiddenField, CommaDecimalField):


### PR DESCRIPTION
## Summary

- Replace defunct `api.exchangerate.host` with `open.er-api.com`, which returns the same JSON structure and is free without an API key
- Remove the blanket workaround in `validate_original_currency` (added in #1232) that blocked all multi-currency bills
- The validator now only raises an error if the rates fetch actually fails or the currency isn't in the returned rates

## Test plan

- [ ] Create a project with EUR as default currency
- [ ] Add a bill with CHF — should convert instead of raising "Failed to convert from CHF currency to EUR"
- [ ] Verify same-currency and no-currency bills still work
- [ ] Simulate API failure and confirm the error message still appears