### PR TITLE
Rate-limit project authentication endpoint

### DIFF
--- a/ihatemoney/tests/budget_test.py
+++ b/ihatemoney/tests/budget_test.py
@@ -694,6 +694,19 @@ class TestBudget(IhatemoneyTestCase):
         finally:
             limiter.enabled = True
 
+    def test_authenticate_throttler(self):
+        self.post_project("raclette")
+
+        # Activate project login throttling by authenticating 4 times with a wrong passsword
+        self.client.post("/authenticate", data={"id": "raclette", "password": "wrong"})
+        self.client.post("/authenticate", data={"id": "raclette", "password": "wrong"})
+        self.client.post("/authenticate", data={"id": "raclette", "password": "wrong"})
+        resp = self.client.post(
+            "/authenticate", data={"id": "raclette", "password": "wrong"}
+        )
+
+        assert "Too many failed login attempts." in resp.data.decode()
+
     def test_manage_bills(self):
         self.post_project("raclette")
 

--- a/ihatemoney/web.py
+++ b/ihatemoney/web.py
@@ -179,20 +179,23 @@ def health():
     return "OK"
 
 
-def admin_limit(limit):
-    return make_response(
-        render_template(
-            "admin.html",
-            breached_limit=limit,
-            limit_message=_("Too many failed login attempts."),
+def login_limit(template_name):
+    def handler(limit):
+        return make_response(
+            render_template(
+                template_name,
+                breached_limit=limit,
+                limit_message=_("Too many failed login attempts."),
+            )
         )
-    )
+
+    return handler
 
 
 @main.route("/admin", methods=["GET", "POST"])
 @limiter.limit(
     "3/minute",
-    on_breach=admin_limit,
+    on_breach=login_limit("admin.html"),
     methods=["POST"],
 )
 def admin():
@@ -255,6 +258,11 @@ def join_project(token):
 
 
 @main.route("/authenticate", methods=["GET", "POST"])
+@limiter.limit(
+    "3/minute",
+    on_breach=login_limit("authenticate.html"),
+    methods=["POST"],
+)
 def authenticate(project_id=None):
     """Authentication form"""
     form = AuthenticationForm()
@@ -283,7 +291,14 @@ def authenticate(project_id=None):
         setattr(g, "project", project)
         return redirect(url_for(".list_bills"))
     if is_post_auth and not check_password_hash(project.password, form.password.data):
-        msg = _("This private code is not the right one")
+        if limiter.current_limit is not None:
+            msg = _(
+                "This private code is not the right one. Only %(num)d attempts left.",
+                # If the limiter is disabled, there is no current limit
+                num=limiter.current_limit.remaining,
+            )
+        else:
+            msg = _("This private code is not the right one")
         form["password"].errors = [msg]
 
     return render_template("authenticate.html", form=form)


### PR DESCRIPTION
Mirror the existing Flask-Limiter throttle already applied to /admin on the /authenticate endpoint, addressing brute-force exposure on the project private-code form. Failed POSTs are limited to 3/minute per IP, after which the breached-limit page is rendered. While attempts remain, the form error surfaces the remaining count, just like the admin form.