### PR TITLE
feature: Add color for inactive members

### DIFF
--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -636,3 +636,10 @@ footer .icon svg {
 .edit-project .custom-file {
   margin-bottom: 2em;
 }
+
+.inactive-member {
+    color: gray;
+    background-color: #f0f0f0;
+    font-style: italic;
+}
+

--- a/ihatemoney/static/css/main.css
+++ b/ihatemoney/static/css/main.css
@@ -639,7 +639,5 @@ footer .icon svg {
 
 .inactive-member {
     color: gray;
-    background-color: #f0f0f0;
     font-style: italic;
 }
-

--- a/ihatemoney/templates/sidebar_table_layout.html
+++ b/ihatemoney/templates/sidebar_table_layout.html
@@ -12,7 +12,7 @@
       </thead>
     {%- endif %}
     {%- for member in g.project.members | sort(attribute='name') if member.activated or balance[member.id]|round(2)|abs > 0.01 %}
-      <tr id="bal-member-{{ member.id }}" action="{% if member.activated %}delete{% else %}reactivate{% endif %}">
+      <tr id="bal-member-{{ member.id }}" class="{% if not member.activated %}inactive-member{% endif %}" action="{% if member.activated %}delete{% else %}reactivate{% endif %}">
         <td class="balance-name">{{ member.name }}
           {%- if show_weight -%}
             <span class="light{% if not g.project.uses_weights %} extra-info{% endif %}">(x{{ member.weight|minimal_round(2) }})</span>

--- a/ihatemoney/tests/main_test.py
+++ b/ihatemoney/tests/main_test.py
@@ -512,3 +512,33 @@ class TestUtils:
         assert get_owers_label(['A', 'B'], ['C']) == ('list', ['C'])
         assert get_owers_label(['A', 'B', 'C'], ['A', 'B']) == ('list', ['A', 'B'])
         assert get_owers_label(['A', 'B', 'C', 'D'], ['A', 'B']) == ('list', ['A', 'B'])
+
+
+class TestInactiveMember(IhatemoneyTestCase):
+    def test_inactive_member_class(self):
+        self.post_project("demo")
+
+        self.client.post("/demo/members/add", data={"name": "Alice"})
+        self.client.post("/demo/members/add", data={"name": "Bob"})
+
+        self.client.post(
+            "/demo/add",
+            data={
+                "date": "2026-06-06",
+                "what": "Test bill",
+                "payer": 1,
+                "payed_for": [1, 2],
+                "amount": "10",
+            },
+        )
+
+        # Deactivate Alice
+        self.client.post("/demo/members/1/delete")
+
+        response = self.client.get("/demo/")
+
+        # Alice should still be listed
+        assert b"Alice" in response.data
+        # And styled as inactive
+        assert b"inactive-member" in response.data
+


### PR DESCRIPTION
This PR addresses issue #1450 opened by @lypwig.

On the members list in the sidebar, it’s possible to deactivate a member. Currently, deactivated members look identical to active ones, which makes it hard to distinguish them.

Changes introduced:
1. Added a conditional CSS class (inactive-member) in the member list template.
2. Updated main.css to style .inactive-member with a gray text color and subtle background.
4. Added a test (TestInactiveMember) to verify that the inactive class is applied correctly.

**Note:**  
I chose gray text with a light gray background for deactivated members. If other collaborators prefer a different color scheme, I’m happy to adjust it based on feedback.