### PR TITLE
Close connection in _pre_alembic_db to fix MySQL 8 migration deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This document describes changes between each past release.
 ## 7.1.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+### Fixed
+- Fix first-database migration deadlock on MySQL 8 by closing the connection opened in `_pre_alembic_db` (#1457)
 
 
 ## 7.1.1 (2026-05-09)

--- a/ihatemoney/run.py
+++ b/ihatemoney/run.py
@@ -36,10 +36,10 @@ def setup_database(app):
 
     def _pre_alembic_db():
         """Checks if we are migrating from a pre-alembic ihatemoney"""
-        con = db.engine.connect()
-        tables_exist = db.engine.dialect.has_table(con, "project")
-        alembic_setup = db.engine.dialect.has_table(con, "alembic_version")
-        return tables_exist and not alembic_setup
+        with db.engine.connect() as con:
+            tables_exist = db.engine.dialect.has_table(con, "project")
+            alembic_setup = db.engine.dialect.has_table(con, "alembic_version")
+            return tables_exist and not alembic_setup
 
     sqlalchemy_url = app.config.get("SQLALCHEMY_DATABASE_URI")
     if sqlalchemy_url.startswith("sqlite:////tmp"):


### PR DESCRIPTION
Fixes #1457.

`_pre_alembic_db()` leaves its `db.engine.connect()` connection open; under SQLAlchemy 2.0 that holds a transaction + metadata locks and deadlocks the first migration on a fresh MySQL 8 database. This closes it via a context manager before `upgrade()` runs — no change on SQLite or already-migrated databases.

Tested against a fresh MySQL 8 (docker-compose + a REST-API smoke test); SQLite unaffected. Happy to add a regression test if wanted.
